### PR TITLE
Allow for method option when differencing

### DIFF
--- a/finitevolx/_src/operators/operators.py
+++ b/finitevolx/_src/operators/operators.py
@@ -13,7 +13,7 @@ from finitevolx._src.interp.interp import (
 
 
 def difference(
-    u: Array, axis: int = 0, step_size: float = 1.0, derivative: int = 1
+    u: Array, axis: int = 0, step_size: float = 1.0, derivative: int = 1, method: string = "central",
 ) -> Array:
     if derivative == 1:
         du = fdx.difference(
@@ -22,7 +22,7 @@ def difference(
             axis=axis,
             accuracy=1,
             derivative=derivative,
-            method="backward",
+            method=method,
         )
         du = jax.lax.slice_in_dim(du, axis=axis, start_index=1, limit_index=None)
     elif derivative == 2:
@@ -32,7 +32,7 @@ def difference(
             axis=axis,
             accuracy=1,
             derivative=derivative,
-            method="central",
+            method=method,
         )
         du = jax.lax.slice_in_dim(du, axis=axis, start_index=1, limit_index=-1)
     else:
@@ -61,6 +61,7 @@ def geostrophic_gradient(
     u: Float[Array, "Nx Ny"],
     dx: float | Array,
     dy: float | Array,
+    method: string = "central",
 ) -> tuple[Float[Array, "Nx Ny-1"], Float[Array, "Nx-1 Ny"]]:
     """Calculates the geostrophic gradient for a staggered grid
 
@@ -85,12 +86,12 @@ def geostrophic_gradient(
         derivative in the x-direction by negative 1.
     """
 
-    du_dy = difference(u=u, axis=1, step_size=dy, derivative=1)
-    dv_dx = difference(u=u, axis=0, step_size=dx, derivative=1)
+    du_dy = difference(u=u, axis=1, step_size=dy, derivative=1, method=method)
+    dv_dx = difference(u=u, axis=0, step_size=dx, derivative=1, method=method)
     return -du_dy, dv_dx
 
 
-def divergence(u: Array, v: Array, dx: float, dy: float) -> Array:
+def divergence(u: Array, v: Array, dx: float, dy: float, method: string = "central") -> Array:
     """Calculates the divergence for a staggered grid
 
     Equation:
@@ -110,9 +111,9 @@ def divergence(u: Array, v: Array, dx: float, dy: float) -> Array:
 
     """
     # ∂xu
-    dudx = difference(u=u, axis=0, step_size=dx, derivative=1)
+    dudx = difference(u=u, axis=0, step_size=dx, derivative=1, method=method)
     # ∂yv
-    dvdx = difference(u=v, axis=1, step_size=dy, derivative=1)
+    dvdx = difference(u=v, axis=1, step_size=dy, derivative=1, method=method)
 
     return dudx + dvdx
 
@@ -122,6 +123,7 @@ def relative_vorticity(
     v: Float[Array, "Nx-1 Ny"],
     dx: float | Array,
     dy: float | Array,
+    method: string = "central",
 ) -> Float[Array, "Nx-1 Ny-1"]:
     """Calculates the relative vorticity by using
     finite difference in the y and x direction for the
@@ -144,11 +146,11 @@ def relative_vorticity(
     """
     # ∂xv
     dv_dx: Float[Array, "Nx-1 Ny-1"] = difference(
-        u=v, axis=0, step_size=dx, derivative=1
+        u=v, axis=0, step_size=dx, derivative=1, method=method
     )
     # ∂yu
     du_dy: Float[Array, "Nx-1 Ny-1"] = difference(
-        u=u, axis=1, step_size=dy, derivative=1
+        u=u, axis=1, step_size=dy, derivative=1, method=method
     )
 
     return dv_dx - du_dy
@@ -190,6 +192,7 @@ def absolute_vorticity(
     v: Float[Array, "Nx-1 Ny"],
     dx: float | Array,
     dy: float | Array,
+    method: string = "central",
 ) -> Float[Array, "Nx-1 Ny-1"]:
     """Calculates the relative vorticity by using
     finite difference in the y and x direction for the
@@ -212,11 +215,11 @@ def absolute_vorticity(
     """
     # ∂xv
     dv_dx: Float[Array, "Nx-1 Ny-1"] = difference(
-        u=v, axis=0, step_size=dx, derivative=1
+        u=v, axis=0, step_size=dx, derivative=1, method=method
     )
     # ∂yu
     du_dy: Float[Array, "Nx-1 Ny-1"] = difference(
-        u=u, axis=1, step_size=dy, derivative=1
+        u=u, axis=1, step_size=dy, derivative=1, method=method
     )
 
     return dv_dx + du_dy

--- a/finitevolx/_src/operators/operators.py
+++ b/finitevolx/_src/operators/operators.py
@@ -13,7 +13,7 @@ from finitevolx._src.interp.interp import (
 
 
 def difference(
-    u: Array, axis: int = 0, step_size: float = 1.0, derivative: int = 1, method: string = "central",
+    u: Array, axis: int = 0, step_size: float = 1.0, derivative: int = 1, method: str = "central",
 ) -> Array:
     if derivative == 1:
         du = fdx.difference(
@@ -61,7 +61,7 @@ def geostrophic_gradient(
     u: Float[Array, "Nx Ny"],
     dx: float | Array,
     dy: float | Array,
-    method: string = "central",
+    method: str = "central",
 ) -> tuple[Float[Array, "Nx Ny-1"], Float[Array, "Nx-1 Ny"]]:
     """Calculates the geostrophic gradient for a staggered grid
 
@@ -91,7 +91,7 @@ def geostrophic_gradient(
     return -du_dy, dv_dx
 
 
-def divergence(u: Array, v: Array, dx: float, dy: float, method: string = "central") -> Array:
+def divergence(u: Array, v: Array, dx: float, dy: float, method: str = "central") -> Array:
     """Calculates the divergence for a staggered grid
 
     Equation:
@@ -123,7 +123,7 @@ def relative_vorticity(
     v: Float[Array, "Nx-1 Ny"],
     dx: float | Array,
     dy: float | Array,
-    method: string = "central",
+    method: str = "central",
 ) -> Float[Array, "Nx-1 Ny-1"]:
     """Calculates the relative vorticity by using
     finite difference in the y and x direction for the
@@ -192,7 +192,7 @@ def absolute_vorticity(
     v: Float[Array, "Nx-1 Ny"],
     dx: float | Array,
     dy: float | Array,
-    method: string = "central",
+    method: str = "central",
 ) -> Float[Array, "Nx-1 Ny-1"]:
     """Calculates the relative vorticity by using
     finite difference in the y and x direction for the

--- a/finitevolx/_src/operators/test_operators.py
+++ b/finitevolx/_src/operators/test_operators.py
@@ -255,7 +255,7 @@ def test_divergence():
     dv_dy_ = difference(v, axis=1, step_size=dy, derivative=1, method="backward")
     div_ = du_dx_ + dv_dy_
     # convenience function
-    div = divergence(u, v, dx=dx, dy=dy)
+    div = divergence(u, v, dx=dx, dy=dy, method="backward")
 
     np.testing.assert_array_almost_equal(div_, div)
 
@@ -271,7 +271,7 @@ def test_relative_vorticity():
     dv_dx_ = difference(v, axis=0, step_size=dx, derivative=1, method="backward")
     vort_r_ = dv_dx_ - du_dy_
     # convenience function
-    vort_r = relative_vorticity(u, v, dx=dx, dy=dy)
+    vort_r = relative_vorticity(u, v, dx=dx, dy=dy, method="backward")
 
     np.testing.assert_array_almost_equal(vort_r_, vort_r)
 
@@ -287,7 +287,7 @@ def test_absolute_vorticity():
     dv_dx_ = difference(v, axis=0, step_size=dx, derivative=1, method="backward")
     vort_r_ = dv_dx_ + du_dy_
     # convenience function
-    vort_r = absolute_vorticity(u, v, dx=dx, dy=dy)
+    vort_r = absolute_vorticity(u, v, dx=dx, dy=dy, method="backward")
 
     np.testing.assert_array_almost_equal(vort_r_, vort_r)
 
@@ -301,7 +301,7 @@ def test_geostrophic_gradient():
     v_ = difference(psi, axis=0, step_size=dx, derivative=1, method="backward")
 
     # convenience function
-    u, v = geostrophic_gradient(psi, dx=dx, dy=dy)
+    u, v = geostrophic_gradient(psi, dx=dx, dy=dy, method="backward")
 
     np.testing.assert_array_almost_equal(u_, u)
     np.testing.assert_array_almost_equal(v_, v)

--- a/finitevolx/_src/operators/test_operators.py
+++ b/finitevolx/_src/operators/test_operators.py
@@ -169,7 +169,7 @@ def test_difference_1d_order2_ones(u_1d_ones):
 
     # classic difference
     du_dx_np = jnp.diff(u_1d_ones, n=2, axis=0) / step_size**derivative
-    du_dx = difference(u_1d_ones, axis=0, step_size=step_size, derivative=derivative, method="backward")
+    du_dx = difference(u_1d_ones, axis=0, step_size=step_size, derivative=derivative)
 
     np.testing.assert_array_almost_equal(du_dx_np, du_dx)
 
@@ -180,7 +180,7 @@ def test_difference_1d_order2_random(u_1d_randn):
 
     # classic difference
     du_dx_np = jnp.diff(u_1d_randn, n=2, axis=0) / step_size**derivative
-    du_dx = difference(u_1d_randn, axis=0, step_size=step_size, derivative=derivative, method="backward")
+    du_dx = difference(u_1d_randn, axis=0, step_size=step_size, derivative=derivative)
 
     np.testing.assert_array_almost_equal(du_dx_np, du_dx)
 
@@ -191,13 +191,13 @@ def test_difference_2d_order2_ones(u_2d_ones):
 
     # classic difference
     du_dx_np = jnp.diff(u_2d_ones, n=derivative, axis=0) / step_size**derivative
-    du_dx = difference(u_2d_ones, axis=0, step_size=step_size, derivative=derivative, method="backward")
+    du_dx = difference(u_2d_ones, axis=0, step_size=step_size, derivative=derivative)
 
     np.testing.assert_array_almost_equal(du_dx_np, du_dx)
 
     # classic difference
     du_dy_np = jnp.diff(u_2d_ones, n=derivative, axis=1) / step_size**derivative
-    du_dy = difference(u_2d_ones, axis=1, step_size=step_size, derivative=derivative, method="backward")
+    du_dy = difference(u_2d_ones, axis=1, step_size=step_size, derivative=derivative)
 
     np.testing.assert_array_almost_equal(du_dy_np, du_dy)
 
@@ -207,12 +207,12 @@ def test_difference_2d_order2_random(u_2d_randn):
     derivative = 2
     # classic difference
     du_dx_np = jnp.diff(u_2d_randn, n=derivative, axis=0) / step_size**derivative
-    du_dx = difference(u_2d_randn, axis=0, step_size=step_size, derivative=derivative, method="backward")
+    du_dx = difference(u_2d_randn, axis=0, step_size=step_size, derivative=derivative)
 
     np.testing.assert_array_almost_equal(du_dx_np, du_dx)
 
     du_dy_np = jnp.diff(u_2d_randn, n=derivative, axis=1) / step_size**derivative
-    du_dy = difference(u_2d_randn, axis=1, step_size=step_size, derivative=derivative, method="backward")
+    du_dy = difference(u_2d_randn, axis=1, step_size=step_size, derivative=derivative)
 
     np.testing.assert_array_almost_equal(du_dy_np, du_dy)
 

--- a/finitevolx/_src/operators/test_operators.py
+++ b/finitevolx/_src/operators/test_operators.py
@@ -117,7 +117,7 @@ def test_difference_1d_order1_ones(u_1d_ones):
 
     # classic difference
     du_dx_np = jnp.diff(u_1d_ones, n=1, axis=0) / step_size
-    du_dx = difference(u_1d_ones, axis=0, step_size=step_size, method='backward')
+    du_dx = difference(u_1d_ones, axis=0, step_size=step_size, method="backward")
 
     np.testing.assert_array_equal(du_dx_np, du_dx)
 
@@ -127,7 +127,7 @@ def test_difference_1d_order1_random(u_1d_randn):
 
     # classic difference
     du_dx_np = jnp.diff(u_1d_randn, n=1, axis=0) / step_size
-    du_dx = difference(u_1d_randn, axis=0, step_size=step_size, method='backward')
+    du_dx = difference(u_1d_randn, axis=0, step_size=step_size, method="backward")
 
     np.testing.assert_array_equal(du_dx_np, du_dx)
 
@@ -137,13 +137,13 @@ def test_difference_2d_order1_ones(u_2d_ones):
 
     # classic difference
     du_dx_np = jnp.diff(u_2d_ones, n=1, axis=0) / step_size
-    du_dx = difference(u_2d_ones, axis=0, step_size=step_size)
+    du_dx = difference(u_2d_ones, axis=0, step_size=step_size, method="backward")
 
     np.testing.assert_array_equal(du_dx_np, du_dx)
 
     # classic difference
     du_dy_np = jnp.diff(u_2d_ones, n=1, axis=1) / step_size
-    du_dy = difference(u_2d_ones, axis=1, step_size=step_size)
+    du_dy = difference(u_2d_ones, axis=1, step_size=step_size, method="backward")
 
     np.testing.assert_array_equal(du_dy_np, du_dy)
 
@@ -153,12 +153,12 @@ def test_difference_2d_order1_random(u_2d_randn):
 
     # classic difference
     du_dx_np = jnp.diff(u_2d_randn, n=1, axis=0) / step_size
-    du_dx = difference(u_2d_randn, axis=0, step_size=step_size)
+    du_dx = difference(u_2d_randn, axis=0, step_size=step_size, method="backward")
 
     np.testing.assert_array_equal(du_dx_np, du_dx)
 
     du_dy_np = jnp.diff(u_2d_randn, n=1, axis=1) / step_size
-    du_dy = difference(u_2d_randn, axis=1, step_size=step_size)
+    du_dy = difference(u_2d_randn, axis=1, step_size=step_size, method="backward")
 
     np.testing.assert_array_equal(du_dy_np, du_dy)
 
@@ -169,7 +169,7 @@ def test_difference_1d_order2_ones(u_1d_ones):
 
     # classic difference
     du_dx_np = jnp.diff(u_1d_ones, n=2, axis=0) / step_size**derivative
-    du_dx = difference(u_1d_ones, axis=0, step_size=step_size, derivative=derivative, method='backward')
+    du_dx = difference(u_1d_ones, axis=0, step_size=step_size, derivative=derivative, method="backward")
 
     np.testing.assert_array_almost_equal(du_dx_np, du_dx)
 
@@ -180,7 +180,7 @@ def test_difference_1d_order2_random(u_1d_randn):
 
     # classic difference
     du_dx_np = jnp.diff(u_1d_randn, n=2, axis=0) / step_size**derivative
-    du_dx = difference(u_1d_randn, axis=0, step_size=step_size, derivative=derivative, method='backward')
+    du_dx = difference(u_1d_randn, axis=0, step_size=step_size, derivative=derivative, method="backward")
 
     np.testing.assert_array_almost_equal(du_dx_np, du_dx)
 
@@ -191,13 +191,13 @@ def test_difference_2d_order2_ones(u_2d_ones):
 
     # classic difference
     du_dx_np = jnp.diff(u_2d_ones, n=derivative, axis=0) / step_size**derivative
-    du_dx = difference(u_2d_ones, axis=0, step_size=step_size, derivative=derivative)
+    du_dx = difference(u_2d_ones, axis=0, step_size=step_size, derivative=derivative, method="backward")
 
     np.testing.assert_array_almost_equal(du_dx_np, du_dx)
 
     # classic difference
     du_dy_np = jnp.diff(u_2d_ones, n=derivative, axis=1) / step_size**derivative
-    du_dy = difference(u_2d_ones, axis=1, step_size=step_size, derivative=derivative)
+    du_dy = difference(u_2d_ones, axis=1, step_size=step_size, derivative=derivative, method="backward")
 
     np.testing.assert_array_almost_equal(du_dy_np, du_dy)
 
@@ -207,12 +207,12 @@ def test_difference_2d_order2_random(u_2d_randn):
     derivative = 2
     # classic difference
     du_dx_np = jnp.diff(u_2d_randn, n=derivative, axis=0) / step_size**derivative
-    du_dx = difference(u_2d_randn, axis=0, step_size=step_size, derivative=derivative)
+    du_dx = difference(u_2d_randn, axis=0, step_size=step_size, derivative=derivative, method="backward")
 
     np.testing.assert_array_almost_equal(du_dx_np, du_dx)
 
     du_dy_np = jnp.diff(u_2d_randn, n=derivative, axis=1) / step_size**derivative
-    du_dy = difference(u_2d_randn, axis=1, step_size=step_size, derivative=derivative)
+    du_dy = difference(u_2d_randn, axis=1, step_size=step_size, derivative=derivative, method="backward")
 
     np.testing.assert_array_almost_equal(du_dy_np, du_dy)
 
@@ -251,8 +251,8 @@ def test_divergence():
     dx, dy = 0.1, 0.2
 
     # gradient froms scratch
-    du_dx_ = difference(u, axis=0, step_size=dx, derivative=1, method='backward')
-    dv_dy_ = difference(v, axis=1, step_size=dy, derivative=1, method='backward')
+    du_dx_ = difference(u, axis=0, step_size=dx, derivative=1, method="backward")
+    dv_dy_ = difference(v, axis=1, step_size=dy, derivative=1, method="backward")
     div_ = du_dx_ + dv_dy_
     # convenience function
     div = divergence(u, v, dx=dx, dy=dy)
@@ -267,8 +267,8 @@ def test_relative_vorticity():
     dx, dy = 0.1, 0.2
 
     # gradient froms scratch
-    du_dy_ = difference(u, axis=1, step_size=dy, derivative=1, method='backward')
-    dv_dx_ = difference(v, axis=0, step_size=dx, derivative=1, method='backward')
+    du_dy_ = difference(u, axis=1, step_size=dy, derivative=1, method="backward")
+    dv_dx_ = difference(v, axis=0, step_size=dx, derivative=1, method="backward")
     vort_r_ = dv_dx_ - du_dy_
     # convenience function
     vort_r = relative_vorticity(u, v, dx=dx, dy=dy)
@@ -283,8 +283,8 @@ def test_absolute_vorticity():
     dx, dy = 0.1, 0.2
 
     # gradient froms scratch
-    du_dy_ = difference(u, axis=1, step_size=dy, derivative=1, method='backward')
-    dv_dx_ = difference(v, axis=0, step_size=dx, derivative=1, method='backward')
+    du_dy_ = difference(u, axis=1, step_size=dy, derivative=1, method="backward")
+    dv_dx_ = difference(v, axis=0, step_size=dx, derivative=1, method="backward")
     vort_r_ = dv_dx_ + du_dy_
     # convenience function
     vort_r = absolute_vorticity(u, v, dx=dx, dy=dy)
@@ -297,8 +297,8 @@ def test_geostrophic_gradient():
     dx, dy = 0.1, 0.2
 
     # gradient froms scratch
-    u_ = -difference(psi, axis=1, step_size=dy, derivative=1, method='backward')
-    v_ = difference(psi, axis=0, step_size=dx, derivative=1, method='backward')
+    u_ = -difference(psi, axis=1, step_size=dy, derivative=1, method="backward")
+    v_ = difference(psi, axis=0, step_size=dx, derivative=1, method="backward")
 
     # convenience function
     u, v = geostrophic_gradient(psi, dx=dx, dy=dy)

--- a/finitevolx/_src/operators/test_operators.py
+++ b/finitevolx/_src/operators/test_operators.py
@@ -117,7 +117,7 @@ def test_difference_1d_order1_ones(u_1d_ones):
 
     # classic difference
     du_dx_np = jnp.diff(u_1d_ones, n=1, axis=0) / step_size
-    du_dx = difference(u_1d_ones, axis=0, step_size=step_size)
+    du_dx = difference(u_1d_ones, axis=0, step_size=step_size, method='backward')
 
     np.testing.assert_array_equal(du_dx_np, du_dx)
 
@@ -127,7 +127,7 @@ def test_difference_1d_order1_random(u_1d_randn):
 
     # classic difference
     du_dx_np = jnp.diff(u_1d_randn, n=1, axis=0) / step_size
-    du_dx = difference(u_1d_randn, axis=0, step_size=step_size)
+    du_dx = difference(u_1d_randn, axis=0, step_size=step_size, method='backward')
 
     np.testing.assert_array_equal(du_dx_np, du_dx)
 
@@ -169,7 +169,7 @@ def test_difference_1d_order2_ones(u_1d_ones):
 
     # classic difference
     du_dx_np = jnp.diff(u_1d_ones, n=2, axis=0) / step_size**derivative
-    du_dx = difference(u_1d_ones, axis=0, step_size=step_size, derivative=derivative)
+    du_dx = difference(u_1d_ones, axis=0, step_size=step_size, derivative=derivative, method='backward')
 
     np.testing.assert_array_almost_equal(du_dx_np, du_dx)
 
@@ -180,7 +180,7 @@ def test_difference_1d_order2_random(u_1d_randn):
 
     # classic difference
     du_dx_np = jnp.diff(u_1d_randn, n=2, axis=0) / step_size**derivative
-    du_dx = difference(u_1d_randn, axis=0, step_size=step_size, derivative=derivative)
+    du_dx = difference(u_1d_randn, axis=0, step_size=step_size, derivative=derivative, method='backward')
 
     np.testing.assert_array_almost_equal(du_dx_np, du_dx)
 
@@ -251,8 +251,8 @@ def test_divergence():
     dx, dy = 0.1, 0.2
 
     # gradient froms scratch
-    du_dx_ = difference(u, axis=0, step_size=dx, derivative=1)
-    dv_dy_ = difference(v, axis=1, step_size=dy, derivative=1)
+    du_dx_ = difference(u, axis=0, step_size=dx, derivative=1, method='backward')
+    dv_dy_ = difference(v, axis=1, step_size=dy, derivative=1, method='backward')
     div_ = du_dx_ + dv_dy_
     # convenience function
     div = divergence(u, v, dx=dx, dy=dy)
@@ -267,8 +267,8 @@ def test_relative_vorticity():
     dx, dy = 0.1, 0.2
 
     # gradient froms scratch
-    du_dy_ = difference(u, axis=1, step_size=dy, derivative=1)
-    dv_dx_ = difference(v, axis=0, step_size=dx, derivative=1)
+    du_dy_ = difference(u, axis=1, step_size=dy, derivative=1, method='backward')
+    dv_dx_ = difference(v, axis=0, step_size=dx, derivative=1, method='backward')
     vort_r_ = dv_dx_ - du_dy_
     # convenience function
     vort_r = relative_vorticity(u, v, dx=dx, dy=dy)
@@ -283,8 +283,8 @@ def test_absolute_vorticity():
     dx, dy = 0.1, 0.2
 
     # gradient froms scratch
-    du_dy_ = difference(u, axis=1, step_size=dy, derivative=1)
-    dv_dx_ = difference(v, axis=0, step_size=dx, derivative=1)
+    du_dy_ = difference(u, axis=1, step_size=dy, derivative=1, method='backward')
+    dv_dx_ = difference(v, axis=0, step_size=dx, derivative=1, method='backward')
     vort_r_ = dv_dx_ + du_dy_
     # convenience function
     vort_r = absolute_vorticity(u, v, dx=dx, dy=dy)
@@ -297,8 +297,8 @@ def test_geostrophic_gradient():
     dx, dy = 0.1, 0.2
 
     # gradient froms scratch
-    u_ = -difference(psi, axis=1, step_size=dy, derivative=1)
-    v_ = difference(psi, axis=0, step_size=dx, derivative=1)
+    u_ = -difference(psi, axis=1, step_size=dy, derivative=1, method='backward')
+    v_ = difference(psi, axis=0, step_size=dx, derivative=1, method='backward')
 
     # convenience function
     u, v = geostrophic_gradient(psi, dx=dx, dy=dy)


### PR DESCRIPTION
I think... the meridional asymmetry we saw in the QG double gyre might be coming from our first-order differencing being `backward`... Do you think it's worth a try to see if changing them to `central` differencing would make a difference?