### PR TITLE
feat(elliptic): make spectral solvers vmap-compatible

### DIFF
--- a/finitevolx/_src/solvers/elliptic.py
+++ b/finitevolx/_src/solvers/elliptic.py
@@ -311,12 +311,13 @@ def solve_helmholtz_dct(
     eigx = dct2_eigenvalues(Nx, dx)
     eigy = dct2_eigenvalues(Ny, dy)
     eig2d = eigy[:, None] + eigx[None, :] - lambda_
-    # Guard the (0,0) null mode when lambda_==0 (Poisson case).
-    # When lambda_!=0, eig2d[0,0] = -lambda_ which is safe.
-    eig2d_safe = jnp.where(eig2d == 0.0, 1.0, eig2d)
+    # Guard only the (0,0) null mode (Laplacian eigenvalues are ≤0 for DCT-II,
+    # so eig2d[0,0] = -lambda_ is zero only when lambda_==0).
+    is_null = eig2d[0, 0] == 0.0
+    eig2d_safe = eig2d.at[0, 0].set(jnp.where(is_null, 1.0, eig2d[0, 0]))
     psi_hat = rhs_hat / eig2d_safe
-    # Zero the (0,0) mode when it was singular (enforces zero-mean gauge)
-    psi_hat = jnp.where(eig2d == 0.0, 0.0, psi_hat)
+    # Zero the (0,0) mode when it was singular (enforces zero-mean gauge).
+    psi_hat = psi_hat.at[0, 0].set(jnp.where(is_null, 0.0, psi_hat[0, 0]))
     # Inverse 2-D DCT-II
     return idctn(psi_hat, type=2, axes=[0, 1])
 
@@ -399,10 +400,15 @@ def solve_helmholtz_fft(
     eigx = fft_eigenvalues(Nx, dx)
     eigy = fft_eigenvalues(Ny, dy)
     eig2d = eigy[:, None] + eigx[None, :] - lambda_
-    # Guard the (0,0) null mode when lambda_==0 (Poisson case).
-    eig2d_safe = jnp.where(eig2d == 0.0, 1.0, eig2d)
+    # Guard only the (0,0) null mode (FFT eigenvalues are ≤0, so
+    # eig2d[0,0] = -lambda_ is zero only when lambda_==0).
+    is_null = eig2d[0, 0] == 0.0
+    eig2d_safe = eig2d.at[0, 0].set(jnp.where(is_null, 1.0, eig2d[0, 0]))
     psi_hat = rhs_hat / eig2d_safe
-    psi_hat = jnp.where(eig2d == 0.0, 0.0, psi_hat)
+    # Zero the (0,0) mode with matching complex dtype.
+    psi_hat = psi_hat.at[0, 0].set(
+        jnp.where(is_null, jnp.zeros_like(psi_hat[0, 0]), psi_hat[0, 0])
+    )
     return jnp.real(jnp.fft.ifft2(psi_hat))
 
 

--- a/tests/test_elliptic.py
+++ b/tests/test_elliptic.py
@@ -512,11 +512,17 @@ class TestVmapSpectralSolvers:
             )
 
     def test_helmholtz_dct_vmap(self, neumann_grid):
-        """Batched DCT Helmholtz with per-mode lambda."""
+        """Batched DCT Helmholtz with per-mode lambda, including lambda=0."""
         Ny, Nx, dx, dy = neumann_grid
-        nl = 3
-        lambdas = jnp.array([-0.5, -1.0, -2.0])
-        rhs = jnp.ones((nl, Ny, Nx))
+        nl = 4
+        lambdas = jnp.array([0.0, -0.5, -1.0, -2.0])
+        rhs = jnp.stack(
+            [
+                jnp.sin(jnp.arange(Ny, dtype=float)[:, None] * (l + 1))
+                * jnp.cos(jnp.arange(Nx, dtype=float)[None, :])
+                for l in range(nl)
+            ]
+        )
         psi_batched = jax.vmap(lambda r, l: solve_helmholtz_dct(r, dx, dy, l))(
             rhs, lambdas
         )
@@ -526,13 +532,24 @@ class TestVmapSpectralSolvers:
             np.testing.assert_allclose(
                 np.array(psi_batched[i]), np.array(psi_single), atol=1e-12
             )
+        # lambda=0 slice should match Poisson
+        psi_poisson = solve_poisson_dct(rhs[0], dx, dy)
+        np.testing.assert_allclose(
+            np.array(psi_batched[0]), np.array(psi_poisson), atol=1e-12
+        )
 
     def test_helmholtz_fft_vmap(self, periodic_grid):
-        """Batched FFT Helmholtz with per-mode lambda."""
+        """Batched FFT Helmholtz with per-mode lambda, including lambda=0."""
         Ny, Nx, dx, dy = periodic_grid
-        nl = 3
-        lambdas = jnp.array([-0.5, -1.0, -2.0])
-        rhs = jnp.ones((nl, Ny, Nx))
+        nl = 4
+        lambdas = jnp.array([0.0, -0.5, -1.0, -2.0])
+        rhs = jnp.stack(
+            [
+                jnp.sin(jnp.arange(Ny, dtype=float)[:, None] * (l + 1))
+                * jnp.cos(jnp.arange(Nx, dtype=float)[None, :])
+                for l in range(nl)
+            ]
+        )
         psi_batched = jax.vmap(lambda r, l: solve_helmholtz_fft(r, dx, dy, l))(
             rhs, lambdas
         )
@@ -542,6 +559,11 @@ class TestVmapSpectralSolvers:
             np.testing.assert_allclose(
                 np.array(psi_batched[i]), np.array(psi_single), atol=1e-12
             )
+        # lambda=0 slice should match Poisson
+        psi_poisson = solve_poisson_fft(rhs[0], dx, dy)
+        np.testing.assert_allclose(
+            np.array(psi_batched[0]), np.array(psi_poisson), atol=1e-12
+        )
 
     def test_poisson_dst_vmap(self, dirichlet_grid):
         """Batched DST Poisson."""
@@ -577,23 +599,33 @@ class TestVmapSpectralSolvers:
         assert psi.shape == (3, Ny, Nx)
 
     def test_helmholtz_dct_vmap_lambda0(self, neumann_grid):
-        """Batched DCT Helmholtz with lambda=0 matches Poisson (zero-mean gauge)."""
+        """Batched DCT Helmholtz with lambda=0 under vmap matches Poisson."""
         Ny, Nx, dx, dy = neumann_grid
-        rhs = jnp.sin(jnp.arange(Ny, dtype=float)[:, None]) * jnp.cos(
-            jnp.arange(Nx, dtype=float)[None, :]
+        nl = 3
+        rhs = jnp.stack(
+            [
+                jnp.sin(jnp.arange(Ny, dtype=float)[:, None] * (l + 1))
+                * jnp.cos(jnp.arange(Nx, dtype=float)[None, :] * (l + 1))
+                for l in range(nl)
+            ]
         )
-        psi_helm = solve_helmholtz_dct(rhs, dx, dy, lambda_=0.0)
-        psi_pois = solve_poisson_dct(rhs, dx, dy)
+        psi_helm = jax.vmap(lambda r: solve_helmholtz_dct(r, dx, dy, lambda_=0.0))(rhs)
+        psi_pois = jax.vmap(lambda r: solve_poisson_dct(r, dx, dy))(rhs)
         np.testing.assert_allclose(np.array(psi_helm), np.array(psi_pois), atol=1e-12)
 
     def test_helmholtz_fft_vmap_lambda0(self, periodic_grid):
-        """Batched FFT Helmholtz with lambda=0 matches Poisson (zero-mean gauge)."""
+        """Batched FFT Helmholtz with lambda=0 under vmap matches Poisson."""
         Ny, Nx, dx, dy = periodic_grid
-        rhs = jnp.sin(jnp.arange(Ny, dtype=float)[:, None]) * jnp.cos(
-            jnp.arange(Nx, dtype=float)[None, :]
+        nl = 3
+        rhs = jnp.stack(
+            [
+                jnp.sin(jnp.arange(Ny, dtype=float)[:, None] * (l + 1))
+                * jnp.cos(jnp.arange(Nx, dtype=float)[None, :] * (l + 1))
+                for l in range(nl)
+            ]
         )
-        psi_helm = solve_helmholtz_fft(rhs, dx, dy, lambda_=0.0)
-        psi_pois = solve_poisson_fft(rhs, dx, dy)
+        psi_helm = jax.vmap(lambda r: solve_helmholtz_fft(r, dx, dy, lambda_=0.0))(rhs)
+        psi_pois = jax.vmap(lambda r: solve_poisson_fft(r, dx, dy))(rhs)
         np.testing.assert_allclose(np.array(psi_helm), np.array(psi_pois), atol=1e-12)
 
 


### PR DESCRIPTION
## Summary
- Replace Python `if lambda_ == 0.0` conditionals in `solve_helmholtz_dct` and `solve_helmholtz_fft` with `jnp.where` guards so `lambda_` can be a JAX tracer under `jax.vmap`
- Enables batched solves over vertical modes with per-mode deformation radii (multi-layer QG)
- All spectral solvers (DST/DCT/FFT Helmholtz & Poisson) and `CapacitanceSolver` verified under vmap
- Added 10 new vmap tests (`TestVmapSpectralSolvers`, `TestVmapCapacitanceSolver`)

Closes #86

## Test plan
- [x] All 43 elliptic tests pass (existing + 10 new vmap tests)
- [x] Helmholtz(lambda=0) still matches Poisson exactly
- [x] Batched capacitance solver matches loop-based single solves
- [x] Lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)