### PR TITLE
feat: spherical diffusion and advection operators (#165)

### DIFF
--- a/finitevolx/__init__.py
+++ b/finitevolx/__init__.py
@@ -23,6 +23,10 @@ from finitevolx._src.advection.reconstruction import (
     Reconstruction2D,
     Reconstruction3D,
 )
+from finitevolx._src.advection.spherical_advection import (
+    SphericalAdvection2D,
+    SphericalAdvection3D,
+)
 from finitevolx._src.advection.weno import (
     weno_3pts,
     weno_3pts_improved,
@@ -69,6 +73,10 @@ from finitevolx._src.diffusion.diffusion import (
     diffusion_2d,
 )
 from finitevolx._src.diffusion.momentum import MomentumAdvection2D, MomentumAdvection3D
+from finitevolx._src.diffusion.spherical_diffusion import (
+    SphericalDiffusion2D,
+    SphericalDiffusion3D,
+)
 from finitevolx._src.grid.base import (
     ArakawaCGrid1D,
     ArakawaCGrid2D,
@@ -336,6 +344,8 @@ __all__ = [
     "Advection1D",
     "Advection2D",
     "Advection3D",
+    "SphericalAdvection2D",
+    "SphericalAdvection3D",
     # WENO stencil functions
     "weno_3pts",
     "weno_3pts_improved",
@@ -443,6 +453,8 @@ __all__ = [
     "BiharmonicDiffusion3D",
     "Diffusion2D",
     "Diffusion3D",
+    "SphericalDiffusion2D",
+    "SphericalDiffusion3D",
     "diffusion_2d",
     # Divergence
     "Divergence2D",

--- a/finitevolx/_src/advection/reconstruction.py
+++ b/finitevolx/_src/advection/reconstruction.py
@@ -31,10 +31,10 @@ from finitevolx._src.advection.weno import (
     weno_9pts as _weno9,
     weno_9pts_right as _weno9_right,
 )
-from finitevolx._src.grid.cartesian import (
-    CartesianGrid1D,
-    CartesianGrid2D,
-    CartesianGrid3D,
+from finitevolx._src.grid.base import (
+    ArakawaCGrid1D,
+    ArakawaCGrid2D,
+    ArakawaCGrid3D,
 )
 from finitevolx._src.mask import Mask2D
 from finitevolx._src.operators._ghost import interior
@@ -289,10 +289,13 @@ class Reconstruction1D(eqx.Module):
 
     Parameters
     ----------
-    grid : CartesianGrid1D
+    grid : ArakawaCGrid1D
+        Any 1-D Arakawa C-grid.  Reconstruction is coordinate-agnostic —
+        the grid is stored for downstream consumers but its spacing
+        fields are never read by the reconstruction stencils themselves.
     """
 
-    grid: CartesianGrid1D
+    grid: ArakawaCGrid1D
 
     def naive_x(
         self,
@@ -574,10 +577,14 @@ class Reconstruction2D(eqx.Module):
 
     Parameters
     ----------
-    grid : CartesianGrid2D
+    grid : ArakawaCGrid2D
+        Any 2-D Arakawa C-grid (Cartesian, spherical, etc.).
+        Reconstruction stencils are coordinate-agnostic — the grid is
+        stored for downstream consumers but the spacing fields are
+        never read by the reconstruction itself.
     """
 
-    grid: CartesianGrid2D
+    grid: ArakawaCGrid2D
 
     def naive_x(
         self,
@@ -1311,10 +1318,13 @@ class Reconstruction3D(eqx.Module):
 
     Parameters
     ----------
-    grid : CartesianGrid3D
+    grid : ArakawaCGrid3D
+        Any 3-D Arakawa C-grid.  Reconstruction stencils are
+        coordinate-agnostic — the grid is stored but its spacing
+        fields are never read by the reconstruction itself.
     """
 
-    grid: CartesianGrid3D
+    grid: ArakawaCGrid3D
 
     def naive_x(
         self,

--- a/finitevolx/_src/advection/spherical_advection.py
+++ b/finitevolx/_src/advection/spherical_advection.py
@@ -1,0 +1,345 @@
+"""
+Spherical-coordinate advection operators for Arakawa C-grids.
+
+Computes ``∂h/∂t = −∇·(h·u_vec)`` on the sphere using face-value
+reconstruction (which is coordinate-independent) followed by a
+spherical flux-divergence::
+
+    ∂h/∂t = − 1/(R·cosφ) · [ ∂(h·u)/∂λ + ∂(h·v·cosφ)/∂φ ]
+
+Only the final flux-divergence step differs from the Cartesian
+:class:`~finitevolx.Advection2D`.  The reconstruction stencils
+(WENO3/5/7/9, WENOz5, TVD with minmod/van_leer/superbee/mc, upwind
+1/2/3, naive) are exactly the Cartesian ones — they take a
+``Float[Array, "Ny Nx"]`` and produce face fluxes on an Arakawa C-grid
+without reading any grid-spacing fields.
+
+The class :class:`SphericalAdvection2D` mirrors the public API of
+:class:`Advection2D` (same ``method`` strings, same mask-adaptive
+stencil dispatch) and differs only by:
+
+* ``grid`` is a :class:`SphericalGrid2D` instead of ``CartesianGrid2D``;
+* the final divergence step applies the cos(lat) metric weights.
+
+At the equator (``cos(lat) = 1``) the spherical operator reduces to
+the Cartesian advection with ``dx = R·dlon`` and ``dy = R·dlat``.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, Bool, Float
+
+from finitevolx._src.advection.advection import (
+    _HIERARCHY_SIZES,
+    _MASK_DISPATCHABLE,
+    _TVD_LIMITERS,
+    _rec_funcs_for_method_2d,
+    _rec_funcs_for_method_3d,
+)
+from finitevolx._src.advection.flux import narrow_mask_hierarchy, upwind_flux
+from finitevolx._src.advection.reconstruction import (
+    Reconstruction2D,
+    Reconstruction3D,
+)
+from finitevolx._src.grid.spherical import SphericalGrid2D, SphericalGrid3D
+from finitevolx._src.mask import Mask2D, Mask3D
+from finitevolx._src.operators._ghost import interior
+from finitevolx._src.operators._utils import _safe_div_cos
+
+
+def _reconstruct_faces_2d(
+    recon: Reconstruction2D,
+    h: Float[Array, "Ny Nx"],
+    u: Float[Array, "Ny Nx"],
+    v: Float[Array, "Ny Nx"],
+    method: str,
+) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
+    """Compute unmasked east/north face fluxes for the given method."""
+    if method == "naive":
+        return recon.naive_x(h, u), recon.naive_y(h, v)
+    if method == "upwind1":
+        return recon.upwind1_x(h, u), recon.upwind1_y(h, v)
+    if method == "upwind2":
+        return recon.upwind2_x(h, u), recon.upwind2_y(h, v)
+    if method == "upwind3":
+        return recon.upwind3_x(h, u), recon.upwind3_y(h, v)
+    if method == "weno3":
+        return recon.weno3_x(h, u), recon.weno3_y(h, v)
+    if method == "weno5":
+        return recon.weno5_x(h, u), recon.weno5_y(h, v)
+    if method == "wenoz5":
+        return recon.wenoz5_x(h, u), recon.wenoz5_y(h, v)
+    if method == "weno7":
+        return recon.weno7_x(h, u), recon.weno7_y(h, v)
+    if method == "weno9":
+        return recon.weno9_x(h, u), recon.weno9_y(h, v)
+    if method in _TVD_LIMITERS:
+        return (
+            recon.tvd_x(h, u, limiter=method),
+            recon.tvd_y(h, v, limiter=method),
+        )
+    raise ValueError(f"Unknown method: {method!r}")
+
+
+def _reconstruct_faces_3d(
+    recon: Reconstruction3D,
+    h: Float[Array, "Nz Ny Nx"],
+    u: Float[Array, "Nz Ny Nx"],
+    v: Float[Array, "Nz Ny Nx"],
+    method: str,
+) -> tuple[Float[Array, "Nz Ny Nx"], Float[Array, "Nz Ny Nx"]]:
+    """Compute unmasked east/north face fluxes for the given 3-D method."""
+    if method == "naive":
+        return recon.naive_x(h, u), recon.naive_y(h, v)
+    if method == "upwind1":
+        return recon.upwind1_x(h, u), recon.upwind1_y(h, v)
+    if method == "weno3":
+        return recon.weno3_x(h, u), recon.weno3_y(h, v)
+    if method == "weno5":
+        return recon.weno5_x(h, u), recon.weno5_y(h, v)
+    if method == "weno7":
+        return recon.weno7_x(h, u), recon.weno7_y(h, v)
+    if method == "weno9":
+        return recon.weno9_x(h, u), recon.weno9_y(h, v)
+    if method in _TVD_LIMITERS:
+        return (
+            recon.tvd_x(h, u, limiter=method),
+            recon.tvd_y(h, v, limiter=method),
+        )
+    raise ValueError(f"Unknown method: {method!r}")
+
+
+class SphericalAdvection2D(eqx.Module):
+    """2-D tracer advection on a spherical Arakawa C-grid.
+
+    Computes ``∂h/∂t = −∇·(h·u_vec)`` on the sphere, using the same
+    Cartesian face-value reconstruction primitives (WENO, TVD, upwind,
+    etc.) and applying the cos(lat) metric weights only in the final
+    flux-divergence step.
+
+    Parameters
+    ----------
+    grid : SphericalGrid2D
+        The underlying 2-D spherical grid.
+    mask : Mask2D or None, optional
+        Optional land/ocean mask.  When provided and a
+        mask-dispatchable method (WENO3/5, WENOz5, any TVD limiter) is
+        used, the ``(2, 4, 6)`` adaptive stencil hierarchies for both
+        directions are pre-built once in ``__init__`` and reused on
+        every call via :func:`upwind_flux` — identical approach to
+        :class:`Advection2D`.  For non-dispatchable methods the
+        unmasked code path runs and the final tendency is post-
+        multiplied by ``mask.h``.  ``None`` (default) gives the
+        unmasked behaviour.  Per #209 Q2 a Cartesian ``Mask2D`` is
+        used pending a dedicated ``SphericalMask2D`` follow-up.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> from finitevolx import SphericalGrid2D, SphericalAdvection2D
+    >>> grid = SphericalGrid2D.from_interior(
+    ...     nx_interior=16,
+    ...     ny_interior=8,
+    ...     lon_range=(0.0, 360.0),
+    ...     lat_range=(-40.0, 40.0),
+    ... )
+    >>> op = SphericalAdvection2D(grid=grid)
+    >>> h = jnp.ones((grid.Ny, grid.Nx))
+    >>> u = jnp.zeros((grid.Ny, grid.Nx))
+    >>> v = jnp.zeros((grid.Ny, grid.Nx))
+    >>> tend = op(h, u, v, method="upwind1")
+    >>> tend.shape
+    (10, 18)
+    """
+
+    grid: SphericalGrid2D
+    mask: Mask2D | None
+    recon: Reconstruction2D
+    _mask_hierarchy_x: dict[int, Bool[Array, "Ny Nx"]] | None
+    _mask_hierarchy_y: dict[int, Bool[Array, "Ny Nx"]] | None
+
+    def __init__(
+        self,
+        grid: SphericalGrid2D,
+        mask: Mask2D | None = None,
+    ) -> None:
+        self.grid = grid
+        self.mask = mask
+        self.recon = Reconstruction2D(grid=grid)
+        if mask is not None:
+            self._mask_hierarchy_x = mask.get_adaptive_masks(
+                direction="x", stencil_sizes=_HIERARCHY_SIZES
+            )
+            self._mask_hierarchy_y = mask.get_adaptive_masks(
+                direction="y", stencil_sizes=_HIERARCHY_SIZES
+            )
+        else:
+            self._mask_hierarchy_x = None
+            self._mask_hierarchy_y = None
+
+    def __call__(
+        self,
+        h: Float[Array, "Ny Nx"],
+        u: Float[Array, "Ny Nx"],
+        v: Float[Array, "Ny Nx"],
+        method: str = "upwind1",
+    ) -> Float[Array, "Ny Nx"]:
+        """Advective tendency ``−∇·(h·u_vec)`` at T-points on a sphere.
+
+        Parameters
+        ----------
+        h : Float[Array, "Ny Nx"]
+            Tracer at T-points.
+        u : Float[Array, "Ny Nx"]
+            Zonal velocity at U-points.
+        v : Float[Array, "Ny Nx"]
+            Meridional velocity at V-points.
+        method : str
+            Reconstruction scheme.  Same alphabet as
+            :meth:`Advection2D.__call__`: ``'naive'``, ``'upwind1'``,
+            ``'upwind2'``, ``'upwind3'``, ``'weno3'``, ``'weno5'``,
+            ``'wenoz5'``, ``'weno7'``, ``'weno9'``, or a TVD limiter
+            (``'minmod'``, ``'van_leer'``, ``'superbee'``, ``'mc'``).
+
+        Returns
+        -------
+        Float[Array, "Ny Nx"]
+            Advective tendency at T-points.  Ghost ring and the
+            outermost interior ring are zero (matching the Cartesian
+            :class:`Advection2D` convention of only writing
+            ``[2:-2, 2:-2]``).
+        """
+        mh_x = self._mask_hierarchy_x
+        mh_y = self._mask_hierarchy_y
+        if mh_x is not None and mh_y is not None and method in _MASK_DISPATCHABLE:
+            rfx, rfy, sizes = _rec_funcs_for_method_2d(self.recon, method)
+            mask_x = narrow_mask_hierarchy(mh_x, sizes)
+            mask_y = narrow_mask_hierarchy(mh_y, sizes)
+            fe = upwind_flux(h, u, dim=1, rec_funcs=rfx, mask_hierarchy=mask_x)
+            fn = upwind_flux(h, v, dim=0, rec_funcs=rfy, mask_hierarchy=mask_y)
+        else:
+            fe, fn = _reconstruct_faces_2d(self.recon, h, u, v, method)
+
+        dlon = self.grid.dlon
+        dlat = self.grid.dlat
+        R = self.grid.R
+
+        # Flux divergence on the sphere at interior cells [2:-2, 2:-2].
+        # Matches the Cartesian Advection2D writing convention
+        # (avoids reading ghost-adjacent flux entries).
+        cos_T_c = self.grid.cos_lat_T[2:-2, 2:-2]
+        cos_V_N = self.grid.cos_lat_V[2:-2, 2:-2]
+        cos_V_S = self.grid.cos_lat_V[1:-3, 2:-2]
+
+        du = (fe[2:-2, 2:-2] - fe[2:-2, 1:-3]) / dlon
+        dv_term = cos_V_N * fn[2:-2, 2:-2] - cos_V_S * fn[1:-3, 2:-2]
+        dv = dv_term / dlat
+        out = interior(-_safe_div_cos(du + dv, cos_T_c, R), h, ghost=2)
+        if self.mask is not None:
+            out = out * self.mask.h
+        return out
+
+
+class SphericalAdvection3D(eqx.Module):
+    """3-D tracer advection on a spherical Arakawa C-grid.
+
+    Applies the 2-D spherical advection stencil independently at each
+    z-level.  Like :class:`Advection3D`, the mask-dispatched path uses
+    native 3-D reconstruction primitives with the z-axis treated as a
+    batch dimension; the unmasked path also uses 3-D reconstruction
+    primitives.
+
+    Parameters
+    ----------
+    grid : SphericalGrid3D
+    mask : Mask3D or None, optional
+        Optional 3-D land/ocean mask.  Pre-builds native 3-D adaptive
+        stencil hierarchies ``(2, 4, 6)`` in both horizontal directions
+        in ``__init__``.  Non-dispatchable methods use the unmasked path
+        and then post-multiply by ``mask.h``.  Per #209 Q2/Q3 a
+        Cartesian ``Mask3D`` is used pending a ``SphericalMask3D``
+        follow-up.
+    """
+
+    grid: SphericalGrid3D
+    mask: Mask3D | None
+    recon: Reconstruction3D
+    _mask_hierarchy_x: dict[int, Bool[Array, "Nz Ny Nx"]] | None
+    _mask_hierarchy_y: dict[int, Bool[Array, "Nz Ny Nx"]] | None
+
+    def __init__(
+        self,
+        grid: SphericalGrid3D,
+        mask: Mask3D | None = None,
+    ) -> None:
+        self.grid = grid
+        self.mask = mask
+        self.recon = Reconstruction3D(grid=grid)
+        if mask is not None:
+            self._mask_hierarchy_x = mask.get_adaptive_masks(
+                direction="x", stencil_sizes=_HIERARCHY_SIZES
+            )
+            self._mask_hierarchy_y = mask.get_adaptive_masks(
+                direction="y", stencil_sizes=_HIERARCHY_SIZES
+            )
+        else:
+            self._mask_hierarchy_x = None
+            self._mask_hierarchy_y = None
+
+    def __call__(
+        self,
+        h: Float[Array, "Nz Ny Nx"],
+        u: Float[Array, "Nz Ny Nx"],
+        v: Float[Array, "Nz Ny Nx"],
+        method: str = "upwind1",
+    ) -> Float[Array, "Nz Ny Nx"]:
+        """3-D advective tendency on a sphere (vmap over z-levels).
+
+        Parameters
+        ----------
+        h : Float[Array, "Nz Ny Nx"]
+            Tracer at T-points.
+        u : Float[Array, "Nz Ny Nx"]
+            Zonal velocity at U-points.
+        v : Float[Array, "Nz Ny Nx"]
+            Meridional velocity at V-points.
+        method : str
+            Reconstruction scheme, same alphabet as
+            :meth:`Advection3D.__call__`.
+
+        Returns
+        -------
+        Float[Array, "Nz Ny Nx"]
+            Advective tendency at T-points.
+        """
+        mh_x = self._mask_hierarchy_x
+        mh_y = self._mask_hierarchy_y
+        if mh_x is not None and mh_y is not None and method in _MASK_DISPATCHABLE:
+            rfx, rfy, sizes = _rec_funcs_for_method_3d(self.recon, method)
+            mask_x = narrow_mask_hierarchy(mh_x, sizes)
+            mask_y = narrow_mask_hierarchy(mh_y, sizes)
+            fe = upwind_flux(h, u, dim=2, rec_funcs=rfx, mask_hierarchy=mask_x)
+            fn = upwind_flux(h, v, dim=1, rec_funcs=rfy, mask_hierarchy=mask_y)
+        else:
+            fe, fn = _reconstruct_faces_3d(self.recon, h, u, v, method)
+
+        dlon = self.grid.dlon
+        dlat = self.grid.dlat
+        R = self.grid.R
+
+        # cos_* arrays are 2-D; broadcast over the leading Nz axis.
+        cos_T_c = self.grid.cos_lat_T[2:-2, 2:-2]
+        cos_V_N = self.grid.cos_lat_V[2:-2, 2:-2]
+        cos_V_S = self.grid.cos_lat_V[1:-3, 2:-2]
+
+        du = (fe[1:-1, 2:-2, 2:-2] - fe[1:-1, 2:-2, 1:-3]) / dlon
+        dv_term = cos_V_N * fn[1:-1, 2:-2, 2:-2] - cos_V_S * fn[1:-1, 1:-3, 2:-2]
+        dv = dv_term / dlat
+        horiz = -_safe_div_cos(du + dv, cos_T_c, R)
+
+        out = jnp.zeros_like(h).at[1:-1, 2:-2, 2:-2].set(horiz)
+        if self.mask is not None:
+            out = out * self.mask.h
+        return out

--- a/finitevolx/_src/advection/spherical_advection.py
+++ b/finitevolx/_src/advection/spherical_advection.py
@@ -8,15 +8,27 @@ spherical flux-divergence::
     ∂h/∂t = − 1/(R·cosφ) · [ ∂(h·u)/∂λ + ∂(h·v·cosφ)/∂φ ]
 
 Only the final flux-divergence step differs from the Cartesian
-:class:`~finitevolx.Advection2D`.  The reconstruction stencils
-(WENO3/5/7/9, WENOz5, TVD with minmod/van_leer/superbee/mc, upwind
-1/2/3, naive) are exactly the Cartesian ones — they take a
-``Float[Array, "Ny Nx"]`` and produce face fluxes on an Arakawa C-grid
-without reading any grid-spacing fields.
+:class:`~finitevolx.Advection2D`.  The reconstruction stencils are
+exactly the Cartesian ones — they take a ``Float[Array, "Ny Nx"]``
+and produce face fluxes on an Arakawa C-grid without reading any
+grid-spacing fields.  The supported ``method`` strings differ by
+dimensionality, matching the corresponding Cartesian operators:
 
-The class :class:`SphericalAdvection2D` mirrors the public API of
-:class:`Advection2D` (same ``method`` strings, same mask-adaptive
-stencil dispatch) and differs only by:
+* :class:`SphericalAdvection2D` (matches :class:`Advection2D`):
+  ``'naive'``, ``'upwind1'``, ``'upwind2'``, ``'upwind3'``,
+  ``'weno3'``, ``'weno5'``, ``'wenoz5'``, ``'weno7'``, ``'weno9'``,
+  and the TVD limiters ``'minmod'``, ``'van_leer'``, ``'superbee'``,
+  ``'mc'``.
+* :class:`SphericalAdvection3D` (matches :class:`Advection3D`) —
+  the 3-D subset: ``'naive'``, ``'upwind1'``, ``'weno3'``,
+  ``'weno5'``, ``'weno7'``, ``'weno9'``, and the TVD limiters.
+  (``upwind2``, ``upwind3``, and ``wenoz5`` are 2-D-only because
+  :class:`~finitevolx.Reconstruction3D` does not expose native 3-D
+  versions of those stencils.)
+
+The spherical 2-D class mirrors the public API of :class:`Advection2D`
+(same ``method`` alphabet, same mask-adaptive stencil dispatch) and
+differs only by:
 
 * ``grid`` is a :class:`SphericalGrid2D` instead of ``CartesianGrid2D``;
 * the final divergence step applies the cos(lat) metric weights.

--- a/finitevolx/_src/diffusion/spherical_diffusion.py
+++ b/finitevolx/_src/diffusion/spherical_diffusion.py
@@ -1,0 +1,398 @@
+"""
+Spherical-coordinate harmonic diffusion operators (flux form).
+
+Computes ``∂h/∂t = ∇·(κ ∇h)`` on an Arakawa C-grid in spherical
+coordinates::
+
+    ∂h/∂t = 1/(R·cosφ) · [∂F_λ/∂λ + ∂(cosφ · F_φ)/∂φ]
+
+with staggered face fluxes
+
+    F_λ = κ · (1/(R·cosφ)) · ∂h/∂λ       at U-points
+    F_φ = κ · (1/R)        · ∂h/∂φ       at V-points
+
+Algorithm (2-D, spacings dlon, dlat in radians, planet radius R)
+----------------------------------------------------------------
+Step 1 — East-face flux at U-points (forward diff T → U)::
+
+    F_λ[j, i+½] = κ · (h[j, i+1] − h[j, i]) / (R · cos(lat_U) · dlon)
+
+Step 2 — North-face flux at V-points (forward diff T → V)::
+
+    F_φ[j+½, i] = κ · (h[j+1, i] − h[j, i]) / (R · dlat)
+
+Step 3 — Tendency at T-points (backward diff of fluxes with cosφ weight on
+the meridional term)::
+
+    dh[j, i] = 1/(R · cos(lat_T)) · [
+        (F_λ[j, i+½] − F_λ[j, i−½]) / dlon
+      + (cos(lat_V_N) · F_φ[j+½, i] − cos(lat_V_S) · F_φ[j−½, i]) / dlat
+    ]
+
+where ``cos(lat_V_N) = cos_lat_V[j, i]`` is the cos(lat) at the north
+face of cell ``[j, i]`` and ``cos(lat_V_S) = cos_lat_V[j−1, i]`` the
+south face.
+
+At the equator (``cos(lat) = 1``) this reduces to the Cartesian
+flux-form Laplacian ``∇·(κ∇h)`` with ``dx = R·dlon`` and
+``dy = R·dlat``.
+
+Boundary conditions
+-------------------
+Face fluxes at domain walls are zero by construction (west, east,
+south, north) — see :mod:`finitevolx._src.diffusion.diffusion` for the
+ghost-ring rationale.  This gives no-flux walls by default.
+
+Pole handling
+-------------
+Any step that divides by ``cos(lat)`` uses :func:`_safe_div_cos` and
+returns NaN where ``|cos(lat)| < 1e-12`` instead of ±inf.
+
+Masking
+-------
+Like the Cartesian :class:`Diffusion2D`, the spherical operator applies
+the three-step intermediate-flux masking pattern when a ``Mask2D`` /
+``Mask3D`` is provided (`#209 <https://github.com/jejjohnson/finitevolX/issues/209>`_):
+
+* ``F_λ *= mask.u``
+* ``F_φ *= mask.v``
+* tendency ``*= mask.h``
+
+Per issue #209 Q2, spherical 2-D operators take a Cartesian ``Mask2D``
+pending a dedicated ``SphericalMask2D`` follow-up.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, Bool, Float
+
+from finitevolx._src.grid.spherical import SphericalGrid2D, SphericalGrid3D
+from finitevolx._src.mask import Mask2D, Mask3D
+from finitevolx._src.operators._ghost import interior, zero_z_ghosts
+from finitevolx._src.operators._utils import _safe_div_cos
+
+
+def _spherical_diffusion_2d_impl(
+    h: Float[Array, "Ny Nx"],
+    kappa: float | Float[Array, "Ny Nx"],
+    dlon: float,
+    dlat: float,
+    R: float,
+    cos_lat_T: Float[Array, "Ny Nx"],
+    cos_lat_U: Float[Array, "Ny Nx"],
+    cos_lat_V: Float[Array, "Ny Nx"],
+    mh: Bool[Array, "Ny Nx"] | Float[Array, "Ny Nx"] | None,
+    mu: Bool[Array, "Ny Nx"] | Float[Array, "Ny Nx"] | None,
+    mv: Bool[Array, "Ny Nx"] | Float[Array, "Ny Nx"] | None,
+) -> Float[Array, "Ny Nx"]:
+    """Shared 2-D spherical diffusion kernel with explicit raw-array masks."""
+    kappa_arr = jnp.asarray(kappa)
+    if kappa_arr.ndim >= 2:
+        kappa_x = kappa_arr[1:-1, 1:-2]
+        kappa_y = kappa_arr[1:-2, 1:-1]
+    else:
+        kappa_x = kappa_arr
+        kappa_y = kappa_arr
+
+    # Step 1 — east-face flux at U-points.
+    # F_lam at U[j, i+1/2] = kappa * (h[j, i+1] - h[j, i]) / (R * cos(lat_U) * dlon)
+    dh_dlon_raw = kappa_x * (h[1:-1, 2:-1] - h[1:-1, 1:-2])
+    cos_U_face = cos_lat_U[1:-1, 1:-2]
+    flux_x_interior = _safe_div_cos(dh_dlon_raw, cos_U_face, R * dlon)
+    flux_x = jnp.zeros_like(h).at[1:-1, 1:-2].set(flux_x_interior)
+    if mu is not None:
+        flux_x = flux_x * mu
+
+    # Step 2 — north-face flux at V-points.
+    # F_phi at V[j+1/2, i] = kappa * (h[j+1, i] - h[j, i]) / (R * dlat)
+    flux_y_interior = kappa_y * (h[2:-1, 1:-1] - h[1:-2, 1:-1]) / (R * dlat)
+    flux_y = jnp.zeros_like(h).at[1:-2, 1:-1].set(flux_y_interior)
+    if mv is not None:
+        flux_y = flux_y * mv
+
+    # Step 3 — tendency at T-points (spherical flux-divergence).
+    cos_V_N = cos_lat_V[1:-1, 1:-1]  # north face of cell [j, i]
+    cos_V_S = cos_lat_V[:-2, 1:-1]  # south face of cell [j, i]
+    cos_T_c = cos_lat_T[1:-1, 1:-1]
+
+    du = (flux_x[1:-1, 1:-1] - flux_x[1:-1, :-2]) / dlon
+    dv = (cos_V_N * flux_y[1:-1, 1:-1] - cos_V_S * flux_y[:-2, 1:-1]) / dlat
+    out = interior(_safe_div_cos(du + dv, cos_T_c, R), h)
+
+    if mh is not None:
+        out = out * mh
+
+    return out
+
+
+def _spherical_diffusion_2d_fluxes_impl(
+    h: Float[Array, "Ny Nx"],
+    kappa: float | Float[Array, "Ny Nx"],
+    dlon: float,
+    dlat: float,
+    R: float,
+    cos_lat_U: Float[Array, "Ny Nx"],
+    mu: Bool[Array, "Ny Nx"] | Float[Array, "Ny Nx"] | None,
+    mv: Bool[Array, "Ny Nx"] | Float[Array, "Ny Nx"] | None,
+) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
+    """Shared diagnostic-flux kernel for :class:`SphericalDiffusion2D`."""
+    kappa_arr = jnp.asarray(kappa)
+    if kappa_arr.ndim >= 2:
+        kappa_x = kappa_arr[1:-1, 1:-2]
+        kappa_y = kappa_arr[1:-2, 1:-1]
+    else:
+        kappa_x = kappa_arr
+        kappa_y = kappa_arr
+
+    dh_dlon_raw = kappa_x * (h[1:-1, 2:-1] - h[1:-1, 1:-2])
+    cos_U_face = cos_lat_U[1:-1, 1:-2]
+    flux_x_interior = _safe_div_cos(dh_dlon_raw, cos_U_face, R * dlon)
+    flux_x = jnp.zeros_like(h).at[1:-1, 1:-2].set(flux_x_interior)
+    if mu is not None:
+        flux_x = flux_x * mu
+
+    flux_y_interior = kappa_y * (h[2:-1, 1:-1] - h[1:-2, 1:-1]) / (R * dlat)
+    flux_y = jnp.zeros_like(h).at[1:-2, 1:-1].set(flux_y_interior)
+    if mv is not None:
+        flux_y = flux_y * mv
+
+    return flux_x, flux_y
+
+
+class SphericalDiffusion2D(eqx.Module):
+    """Horizontal tracer diffusion (flux form) on a 2-D spherical C-grid.
+
+    Computes ``∂h/∂t = ∇·(κ ∇h)`` at T-points from staggered face
+    fluxes, applying the cos(lat) metric terms inside the zonal flux
+    and the meridional flux-divergence (see module docstring for the
+    full stencil).
+
+    Parameters
+    ----------
+    grid : SphericalGrid2D
+        The underlying 2-D spherical Arakawa C-grid.
+    mask : Mask2D or None, optional
+        Optional land/ocean mask.  When provided, the three-step
+        intermediate-flux masking pattern is applied inside both
+        :meth:`__call__` and :meth:`fluxes`:
+
+        * ``flux_x *= mask.u`` at the U-face stage,
+        * ``flux_y *= mask.v`` at the V-face stage,
+        * tendency ``*= mask.h`` on the final output (``__call__`` only).
+
+        Per #209 Q2, this is a Cartesian ``Mask2D`` pending a dedicated
+        ``SphericalMask2D`` follow-up.  ``None`` (default) gives the
+        unmasked behaviour.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> from finitevolx import SphericalGrid2D, SphericalDiffusion2D
+    >>> grid = SphericalGrid2D.from_interior(
+    ...     nx_interior=16,
+    ...     ny_interior=8,
+    ...     lon_range=(0.0, 360.0),
+    ...     lat_range=(-40.0, 40.0),
+    ...     R=6.371e6,
+    ... )
+    >>> op = SphericalDiffusion2D(grid=grid)
+    >>> h = jnp.ones((grid.Ny, grid.Nx))
+    >>> tend = op(h, kappa=1e3)
+    >>> tend.shape
+    (10, 18)
+    """
+
+    grid: SphericalGrid2D
+    mask: Mask2D | None = None
+
+    def __call__(
+        self,
+        h: Float[Array, "Ny Nx"],
+        kappa: float | Float[Array, "Ny Nx"],
+    ) -> Float[Array, "Ny Nx"]:
+        """Harmonic diffusion tendency at T-points.
+
+        Parameters
+        ----------
+        h : Float[Array, "Ny Nx"]
+            Tracer field at T-points.
+        kappa : float or Float[Array, "Ny Nx"]
+            Diffusion coefficient (scalar or T-point field).  When an
+            array, the value at the source (western/southern) T-cell
+            is used for each face flux.
+
+        Returns
+        -------
+        Float[Array, "Ny Nx"]
+            Diffusion tendency at T-points.  Ghost ring is zero.
+        """
+        mh = None if self.mask is None else self.mask.h
+        mu = None if self.mask is None else self.mask.u
+        mv = None if self.mask is None else self.mask.v
+        return _spherical_diffusion_2d_impl(
+            h,
+            kappa,
+            self.grid.dlon,
+            self.grid.dlat,
+            self.grid.R,
+            self.grid.cos_lat_T,
+            self.grid.cos_lat_U,
+            self.grid.cos_lat_V,
+            mh=mh,
+            mu=mu,
+            mv=mv,
+        )
+
+    def fluxes(
+        self,
+        h: Float[Array, "Ny Nx"],
+        kappa: float | Float[Array, "Ny Nx"],
+    ) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
+        """Diagnostic diffusive face fluxes at U- and V-points.
+
+        Returns the metric-scaled east-face and north-face fluxes before
+        the spherical divergence step::
+
+            F_λ[j, i+½] = κ · (h[j, i+1] − h[j, i]) / (R · cos(lat_U) · dlon)
+            F_φ[j+½, i] = κ · (h[j+1, i] − h[j, i]) / (R · dlat)
+
+        Parameters
+        ----------
+        h : Float[Array, "Ny Nx"]
+            Tracer field at T-points.
+        kappa : float or Float[Array, "Ny Nx"]
+            Diffusion coefficient.
+
+        Returns
+        -------
+        tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]
+            ``(flux_x, flux_y)``.  Masked by ``mask.u`` / ``mask.v``
+            when ``self.mask`` is set.
+        """
+        mu = None if self.mask is None else self.mask.u
+        mv = None if self.mask is None else self.mask.v
+        return _spherical_diffusion_2d_fluxes_impl(
+            h,
+            kappa,
+            self.grid.dlon,
+            self.grid.dlat,
+            self.grid.R,
+            self.grid.cos_lat_U,
+            mu=mu,
+            mv=mv,
+        )
+
+
+class SphericalDiffusion3D(eqx.Module):
+    """Horizontal tracer diffusion on a 3-D spherical Arakawa C-grid.
+
+    Applies :class:`SphericalDiffusion2D` independently at each z-level
+    via ``eqx.filter_vmap``.  The 3-D field shape is ``[Nz, Ny, Nx]``.
+
+    Parameters
+    ----------
+    grid : SphericalGrid3D
+    mask : Mask3D or None, optional
+        Optional 3-D land/ocean mask.  When provided, the intermediate
+        flux masking pattern from :class:`SphericalDiffusion2D` is
+        applied at every z-level with per-z slices of ``mask.h``,
+        ``mask.u``, ``mask.v`` — same approach as :class:`Diffusion3D`.
+    """
+
+    grid: SphericalGrid3D
+    mask: Mask3D | None = None
+
+    def __call__(
+        self,
+        h: Float[Array, "Nz Ny Nx"],
+        kappa: float | Float[Array, "Nz Ny Nx"],
+    ) -> Float[Array, "Nz Ny Nx"]:
+        """Diffusion tendency at T-points over all z-levels."""
+        dlon, dlat, R = self.grid.dlon, self.grid.dlat, self.grid.R
+        cos_T = self.grid.cos_lat_T
+        cos_U = self.grid.cos_lat_U
+        cos_V = self.grid.cos_lat_V
+
+        kappa_arr = jnp.asarray(kappa)
+        kappa_ax = 0 if kappa_arr.ndim >= 3 else None
+
+        if self.mask is None:
+
+            def _apply(h_k, kap_k):
+                return _spherical_diffusion_2d_impl(
+                    h_k,
+                    kap_k,
+                    dlon,
+                    dlat,
+                    R,
+                    cos_T,
+                    cos_U,
+                    cos_V,
+                    mh=None,
+                    mu=None,
+                    mv=None,
+                )
+
+            out = eqx.filter_vmap(_apply, in_axes=(0, kappa_ax))(h, kappa_arr)
+            return zero_z_ghosts(out)
+
+        mh = self.mask.h
+        mu = self.mask.u
+        mv = self.mask.v
+
+        def _apply_masked(h_k, kap_k, mh_k, mu_k, mv_k):
+            return _spherical_diffusion_2d_impl(
+                h_k,
+                kap_k,
+                dlon,
+                dlat,
+                R,
+                cos_T,
+                cos_U,
+                cos_V,
+                mh=mh_k,
+                mu=mu_k,
+                mv=mv_k,
+            )
+
+        out = eqx.filter_vmap(_apply_masked, in_axes=(0, kappa_ax, 0, 0, 0))(
+            h, kappa_arr, mh, mu, mv
+        )
+        return zero_z_ghosts(out)
+
+    def fluxes(
+        self,
+        h: Float[Array, "Nz Ny Nx"],
+        kappa: float | Float[Array, "Nz Ny Nx"],
+    ) -> tuple[Float[Array, "Nz Ny Nx"], Float[Array, "Nz Ny Nx"]]:
+        """Diagnostic diffusive face fluxes at U- and V-points, all z."""
+        dlon, dlat, R = self.grid.dlon, self.grid.dlat, self.grid.R
+        cos_U = self.grid.cos_lat_U
+
+        kappa_arr = jnp.asarray(kappa)
+        kappa_ax = 0 if kappa_arr.ndim >= 3 else None
+
+        if self.mask is None:
+
+            def _apply(h_k, kap_k):
+                return _spherical_diffusion_2d_fluxes_impl(
+                    h_k, kap_k, dlon, dlat, R, cos_U, mu=None, mv=None
+                )
+
+            fx, fy = eqx.filter_vmap(_apply, in_axes=(0, kappa_ax))(h, kappa_arr)
+            return zero_z_ghosts(fx), zero_z_ghosts(fy)
+
+        mu = self.mask.u
+        mv = self.mask.v
+
+        def _apply_masked(h_k, kap_k, mu_k, mv_k):
+            return _spherical_diffusion_2d_fluxes_impl(
+                h_k, kap_k, dlon, dlat, R, cos_U, mu=mu_k, mv=mv_k
+            )
+
+        fx, fy = eqx.filter_vmap(_apply_masked, in_axes=(0, kappa_ax, 0, 0))(
+            h, kappa_arr, mu, mv
+        )
+        return zero_z_ghosts(fx), zero_z_ghosts(fy)

--- a/tests/test_spherical_advection.py
+++ b/tests/test_spherical_advection.py
@@ -1,0 +1,359 @@
+"""Tests for SphericalAdvection2D and SphericalAdvection3D."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from finitevolx._src.advection.advection import Advection2D, Advection3D
+from finitevolx._src.advection.spherical_advection import (
+    SphericalAdvection2D,
+    SphericalAdvection3D,
+)
+from finitevolx._src.grid.cartesian import CartesianGrid2D, CartesianGrid3D
+from finitevolx._src.grid.spherical import SphericalGrid2D, SphericalGrid3D
+from finitevolx._src.mask import Mask2D, Mask3D
+
+jax.config.update("jax_enable_x64", True)
+
+
+R = 6.371e6
+NX_INT, NY_INT = 16, 10
+
+
+@pytest.fixture
+def grid():
+    return SphericalGrid2D.from_interior(
+        nx_interior=NX_INT,
+        ny_interior=NY_INT,
+        lon_range=(0.0, 360.0),
+        lat_range=(-40.0, 40.0),
+        R=R,
+    )
+
+
+@pytest.fixture
+def grid3d():
+    return SphericalGrid3D.from_interior(
+        nx_interior=NX_INT,
+        ny_interior=NY_INT,
+        nz_interior=3,
+        lon_range=(0.0, 360.0),
+        lat_range=(-40.0, 40.0),
+        Lz=100.0,
+        R=R,
+    )
+
+
+# ======================================================================
+# SphericalAdvection2D
+# ======================================================================
+
+
+class TestSphericalAdvection2D:
+    @pytest.fixture
+    def op(self, grid):
+        return SphericalAdvection2D(grid=grid)
+
+    def test_output_shape(self, op, grid):
+        h = jnp.ones((grid.Ny, grid.Nx))
+        u = jnp.zeros((grid.Ny, grid.Nx))
+        v = jnp.zeros((grid.Ny, grid.Nx))
+        out = op(h, u, v)
+        assert out.shape == (grid.Ny, grid.Nx)
+
+    def test_zero_velocity_zero_tendency(self, op, grid):
+        key = jax.random.PRNGKey(0)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        u = jnp.zeros_like(h)
+        v = jnp.zeros_like(h)
+        out = op(h, u, v, method="upwind1")
+        np.testing.assert_allclose(out, 0.0, atol=1e-12)
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "upwind1",
+            "upwind2",
+            "upwind3",
+            "weno3",
+            "weno5",
+            "wenoz5",
+            "minmod",
+            "van_leer",
+            "superbee",
+            "mc",
+        ],
+    )
+    def test_methods_produce_finite_output(self, op, grid, method):
+        key = jax.random.PRNGKey(1)
+        k1, k2, k3 = jax.random.split(key, 3)
+        h = jax.random.normal(k1, (grid.Ny, grid.Nx))
+        u = jax.random.normal(k2, (grid.Ny, grid.Nx))
+        v = jax.random.normal(k3, (grid.Ny, grid.Nx))
+        out = op(h, u, v, method=method)
+        assert jnp.all(jnp.isfinite(out))
+
+    def test_ghost_ring_zero(self, op, grid):
+        key = jax.random.PRNGKey(2)
+        k1, k2, k3 = jax.random.split(key, 3)
+        h = jax.random.normal(k1, (grid.Ny, grid.Nx))
+        u = jax.random.normal(k2, (grid.Ny, grid.Nx))
+        v = jax.random.normal(k3, (grid.Ny, grid.Nx))
+        out = op(h, u, v, method="upwind1")
+        np.testing.assert_allclose(out[0, :], 0.0)
+        np.testing.assert_allclose(out[-1, :], 0.0)
+        np.testing.assert_allclose(out[:, 0], 0.0)
+        np.testing.assert_allclose(out[:, -1], 0.0)
+
+    def test_matches_cartesian_at_narrow_equatorial_band(self):
+        """Spherical advection at the equator (cos≈1) should match
+        Cartesian advection with dx=R·dlon, dy=R·dlat."""
+        nx, ny = 24, 6
+        lon_range = (0.0, 30.0)
+        lat_range = (-0.5, 0.5)
+        sphere = SphericalGrid2D.from_interior(
+            nx_interior=nx,
+            ny_interior=ny,
+            lon_range=lon_range,
+            lat_range=lat_range,
+            R=R,
+        )
+        cart = CartesianGrid2D.from_interior(
+            nx_interior=nx,
+            ny_interior=ny,
+            Lx=sphere.Lx,
+            Ly=sphere.Ly,
+        )
+        key = jax.random.PRNGKey(3)
+        k1, k2, k3 = jax.random.split(key, 3)
+        h = jax.random.normal(k1, (sphere.Ny, sphere.Nx))
+        u = jax.random.normal(k2, (sphere.Ny, sphere.Nx))
+        v = jax.random.normal(k3, (sphere.Ny, sphere.Nx))
+
+        sph_op = SphericalAdvection2D(grid=sphere)
+        cart_op = Advection2D(grid=cart)
+
+        for method in ("upwind1", "weno3", "weno5"):
+            t_s = sph_op(h, u, v, method=method)
+            t_c = cart_op(h, u, v, method=method)
+            # Across 1-degree latitude, cos varies by O(1e-4).
+            np.testing.assert_allclose(
+                t_s[2:-2, 2:-2],
+                t_c[2:-2, 2:-2],
+                rtol=5e-3,
+                atol=1e-3,
+            )
+
+    def test_jit(self, op, grid):
+        key = jax.random.PRNGKey(4)
+        k1, k2, k3 = jax.random.split(key, 3)
+        h = jax.random.normal(k1, (grid.Ny, grid.Nx))
+        u = jax.random.normal(k2, (grid.Ny, grid.Nx))
+        v = jax.random.normal(k3, (grid.Ny, grid.Nx))
+        out = jax.jit(lambda a, b, c: op(a, b, c, method="weno5"))(h, u, v)
+        assert out.shape == h.shape
+        assert jnp.all(jnp.isfinite(out))
+
+    def test_grad(self, op, grid):
+        key = jax.random.PRNGKey(5)
+        k1, k2, k3 = jax.random.split(key, 3)
+        h = jax.random.normal(k1, (grid.Ny, grid.Nx))
+        u = jax.random.normal(k2, (grid.Ny, grid.Nx))
+        v = jax.random.normal(k3, (grid.Ny, grid.Nx))
+
+        def loss(h_, u_, v_):
+            return op(h_, u_, v_, method="upwind1").sum()
+
+        gh, gu, gv = jax.grad(loss, argnums=(0, 1, 2))(h, u, v)
+        for g in (gh, gu, gv):
+            assert g.shape == h.shape
+            assert jnp.all(jnp.isfinite(g))
+
+    def test_uniform_h_positive_u_zero_v(self, grid):
+        """Uniform h with uniform u>0 → -div(h·u·cosφ) dependence.
+
+        For h constant and v=0:
+            dh/dt = -(1/(R·cosφ))·∂(h·u)/∂λ
+        If additionally u is uniform in λ, this term is zero. Verify.
+        """
+        op = SphericalAdvection2D(grid=grid)
+        h = 2.0 * jnp.ones((grid.Ny, grid.Nx))
+        u = 1.5 * jnp.ones((grid.Ny, grid.Nx))
+        v = jnp.zeros_like(h)
+        out = op(h, u, v, method="upwind1")
+        np.testing.assert_allclose(out[2:-2, 2:-2], 0.0, atol=1e-10)
+
+
+# ======================================================================
+# Masking
+# ======================================================================
+
+
+class TestSphericalAdvection2DMasked:
+    def test_all_dry_mask_zero(self, grid):
+        all_dry = Mask2D.from_mask(np.zeros((grid.Ny, grid.Nx), dtype=bool))
+        op = SphericalAdvection2D(grid=grid, mask=all_dry)
+        key = jax.random.PRNGKey(6)
+        k1, k2, k3 = jax.random.split(key, 3)
+        h = jax.random.normal(k1, (grid.Ny, grid.Nx))
+        u = jax.random.normal(k2, (grid.Ny, grid.Nx))
+        v = jax.random.normal(k3, (grid.Ny, grid.Nx))
+        out = op(h, u, v, method="weno3")
+        np.testing.assert_allclose(out, 0.0, atol=1e-12)
+
+    def test_all_wet_matches_unmasked_upwind1(self, grid):
+        all_wet = Mask2D.from_mask(np.ones((grid.Ny, grid.Nx), dtype=bool))
+        op_m = SphericalAdvection2D(grid=grid, mask=all_wet)
+        op_u = SphericalAdvection2D(grid=grid)
+        key = jax.random.PRNGKey(7)
+        k1, k2, k3 = jax.random.split(key, 3)
+        h = jax.random.normal(k1, (grid.Ny, grid.Nx))
+        u = jax.random.normal(k2, (grid.Ny, grid.Nx))
+        v = jax.random.normal(k3, (grid.Ny, grid.Nx))
+        # Non-dispatchable method — should match bit-for-bit.
+        np.testing.assert_allclose(
+            op_m(h, u, v, method="upwind1"),
+            op_u(h, u, v, method="upwind1"),
+            atol=1e-12,
+        )
+
+    def test_dry_cell_tendency_zero(self, grid):
+        mask = np.ones((grid.Ny, grid.Nx), dtype=bool)
+        mask[4, 6] = False
+        op = SphericalAdvection2D(grid=grid, mask=Mask2D.from_mask(mask))
+        key = jax.random.PRNGKey(8)
+        k1, k2, k3 = jax.random.split(key, 3)
+        h = jax.random.normal(k1, (grid.Ny, grid.Nx))
+        u = jax.random.normal(k2, (grid.Ny, grid.Nx))
+        v = jax.random.normal(k3, (grid.Ny, grid.Nx))
+        out = op(h, u, v, method="weno3")
+        assert float(out[4, 6]) == 0.0
+
+
+# ======================================================================
+# SphericalAdvection3D
+# ======================================================================
+
+
+class TestSphericalAdvection3D:
+    @pytest.fixture
+    def op(self, grid3d):
+        return SphericalAdvection3D(grid=grid3d)
+
+    def test_output_shape(self, op, grid3d):
+        shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+        h = jnp.ones(shape)
+        u = jnp.zeros(shape)
+        v = jnp.zeros(shape)
+        out = op(h, u, v)
+        assert out.shape == shape
+
+    def test_zero_velocity_zero_tendency(self, op, grid3d):
+        key = jax.random.PRNGKey(9)
+        h = jax.random.normal(key, (grid3d.Nz, grid3d.Ny, grid3d.Nx))
+        u = jnp.zeros_like(h)
+        v = jnp.zeros_like(h)
+        out = op(h, u, v, method="upwind1")
+        np.testing.assert_allclose(out, 0.0, atol=1e-12)
+
+    def test_z_ghost_slices_zero(self, op, grid3d):
+        key = jax.random.PRNGKey(10)
+        k1, k2, k3 = jax.random.split(key, 3)
+        shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+        h = jax.random.normal(k1, shape)
+        u = jax.random.normal(k2, shape)
+        v = jax.random.normal(k3, shape)
+        out = op(h, u, v, method="weno3")
+        np.testing.assert_allclose(out[0, :, :], 0.0, atol=1e-10)
+        np.testing.assert_allclose(out[-1, :, :], 0.0, atol=1e-10)
+
+    def test_matches_2d_per_level(self, op, grid3d):
+        """On a z-broadcast field, the 3-D spherical advection equals
+        the 2-D spherical advection at each interior level."""
+        op2d = SphericalAdvection2D(grid=grid3d.horizontal_grid())
+        key = jax.random.PRNGKey(11)
+        k1, k2, k3 = jax.random.split(key, 3)
+        h_2d = jax.random.normal(k1, (grid3d.Ny, grid3d.Nx))
+        u_2d = jax.random.normal(k2, (grid3d.Ny, grid3d.Nx))
+        v_2d = jax.random.normal(k3, (grid3d.Ny, grid3d.Nx))
+        shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+        h_3d = jnp.broadcast_to(h_2d, shape)
+        u_3d = jnp.broadcast_to(u_2d, shape)
+        v_3d = jnp.broadcast_to(v_2d, shape)
+
+        t_2d = op2d(h_2d, u_2d, v_2d, method="weno3")
+        t_3d = op(h_3d, u_3d, v_3d, method="weno3")
+
+        for k in range(1, grid3d.Nz - 1):
+            np.testing.assert_allclose(t_3d[k], t_2d, atol=1e-12)
+
+    def test_matches_cartesian_at_narrow_equatorial_band(self):
+        """Narrow lat band around equator → spherical 3D ≈ Cartesian 3D."""
+        nx, ny, nz = 16, 6, 3
+        sphere = SphericalGrid3D.from_interior(
+            nx_interior=nx,
+            ny_interior=ny,
+            nz_interior=nz,
+            lon_range=(0.0, 20.0),
+            lat_range=(-0.5, 0.5),
+            Lz=100.0,
+            R=R,
+        )
+        cart = CartesianGrid3D.from_interior(
+            nx_interior=nx,
+            ny_interior=ny,
+            nz_interior=nz,
+            Lx=sphere.Lx,
+            Ly=sphere.Ly,
+            Lz=100.0,
+        )
+        key = jax.random.PRNGKey(12)
+        k1, k2, k3 = jax.random.split(key, 3)
+        shape = (sphere.Nz, sphere.Ny, sphere.Nx)
+        h = jax.random.normal(k1, shape)
+        u = jax.random.normal(k2, shape)
+        v = jax.random.normal(k3, shape)
+
+        op_s = SphericalAdvection3D(grid=sphere)
+        op_c = Advection3D(grid=cart)
+
+        for method in ("upwind1", "weno3"):
+            t_s = op_s(h, u, v, method=method)
+            t_c = op_c(h, u, v, method=method)
+            np.testing.assert_allclose(
+                t_s[1:-1, 2:-2, 2:-2],
+                t_c[1:-1, 2:-2, 2:-2],
+                rtol=5e-3,
+                atol=1e-3,
+            )
+
+    def test_masked_all_dry_zero(self, grid3d):
+        all_dry = Mask3D.from_mask(
+            np.zeros((grid3d.Nz, grid3d.Ny, grid3d.Nx), dtype=bool)
+        )
+        op = SphericalAdvection3D(grid=grid3d, mask=all_dry)
+        key = jax.random.PRNGKey(13)
+        k1, k2, k3 = jax.random.split(key, 3)
+        shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+        h = jax.random.normal(k1, shape)
+        u = jax.random.normal(k2, shape)
+        v = jax.random.normal(k3, shape)
+        out = op(h, u, v, method="weno3")
+        np.testing.assert_allclose(out, 0.0, atol=1e-12)
+
+    def test_jit_grad(self, op, grid3d):
+        key = jax.random.PRNGKey(14)
+        k1, k2, k3 = jax.random.split(key, 3)
+        shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+        h = jax.random.normal(k1, shape)
+        u = jax.random.normal(k2, shape)
+        v = jax.random.normal(k3, shape)
+        jitted = jax.jit(lambda a, b, c: op(a, b, c, method="weno3"))
+        out = jitted(h, u, v)
+        assert out.shape == shape
+        g = jax.grad(lambda a: op(a, u, v, method="upwind1").sum())(h)
+        assert g.shape == shape
+        assert jnp.all(jnp.isfinite(g))

--- a/tests/test_spherical_advection.py
+++ b/tests/test_spherical_advection.py
@@ -75,12 +75,15 @@ class TestSphericalAdvection2D:
     @pytest.mark.parametrize(
         "method",
         [
+            "naive",
             "upwind1",
             "upwind2",
             "upwind3",
             "weno3",
             "weno5",
             "wenoz5",
+            "weno7",
+            "weno9",
             "minmod",
             "van_leer",
             "superbee",
@@ -258,6 +261,31 @@ class TestSphericalAdvection3D:
         v = jnp.zeros_like(h)
         out = op(h, u, v, method="upwind1")
         np.testing.assert_allclose(out, 0.0, atol=1e-12)
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "naive",
+            "upwind1",
+            "weno3",
+            "weno5",
+            "weno7",
+            "weno9",
+            "minmod",
+            "van_leer",
+            "superbee",
+            "mc",
+        ],
+    )
+    def test_methods_produce_finite_output(self, op, grid3d, method):
+        key = jax.random.PRNGKey(15)
+        k1, k2, k3 = jax.random.split(key, 3)
+        shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+        h = jax.random.normal(k1, shape)
+        u = jax.random.normal(k2, shape)
+        v = jax.random.normal(k3, shape)
+        out = op(h, u, v, method=method)
+        assert jnp.all(jnp.isfinite(out))
 
     def test_z_ghost_slices_zero(self, op, grid3d):
         key = jax.random.PRNGKey(10)

--- a/tests/test_spherical_diffusion.py
+++ b/tests/test_spherical_diffusion.py
@@ -1,0 +1,284 @@
+"""Tests for SphericalDiffusion2D and SphericalDiffusion3D."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from finitevolx._src.diffusion.diffusion import Diffusion2D
+from finitevolx._src.diffusion.spherical_diffusion import (
+    SphericalDiffusion2D,
+    SphericalDiffusion3D,
+)
+from finitevolx._src.grid.cartesian import CartesianGrid2D
+from finitevolx._src.grid.spherical import SphericalGrid2D, SphericalGrid3D
+from finitevolx._src.mask import Mask2D, Mask3D
+
+jax.config.update("jax_enable_x64", True)
+
+
+R = 6.371e6
+NX_INT, NY_INT = 16, 10
+
+
+@pytest.fixture
+def grid():
+    return SphericalGrid2D.from_interior(
+        nx_interior=NX_INT,
+        ny_interior=NY_INT,
+        lon_range=(0.0, 360.0),
+        lat_range=(-40.0, 40.0),
+        R=R,
+    )
+
+
+@pytest.fixture
+def grid3d():
+    return SphericalGrid3D.from_interior(
+        nx_interior=NX_INT,
+        ny_interior=NY_INT,
+        nz_interior=3,
+        lon_range=(0.0, 360.0),
+        lat_range=(-40.0, 40.0),
+        Lz=100.0,
+        R=R,
+    )
+
+
+@pytest.fixture
+def diff_op(grid):
+    return SphericalDiffusion2D(grid=grid)
+
+
+@pytest.fixture
+def diff_op3d(grid3d):
+    return SphericalDiffusion3D(grid=grid3d)
+
+
+# ======================================================================
+# SphericalDiffusion2D
+# ======================================================================
+
+
+class TestSphericalDiffusion2D:
+    def test_output_shape(self, diff_op, grid):
+        h = jnp.zeros((grid.Ny, grid.Nx))
+        out = diff_op(h, kappa=1.0)
+        assert out.shape == (grid.Ny, grid.Nx)
+
+    def test_ghost_ring_is_zero(self, diff_op, grid):
+        h = jnp.ones((grid.Ny, grid.Nx))
+        out = diff_op(h, kappa=1.0)
+        np.testing.assert_allclose(out[0, :], 0.0)
+        np.testing.assert_allclose(out[-1, :], 0.0)
+        np.testing.assert_allclose(out[:, 0], 0.0)
+        np.testing.assert_allclose(out[:, -1], 0.0)
+
+    def test_constant_tracer_zero_tendency(self, diff_op, grid):
+        """Constant h → zero tendency everywhere (including non-constant cos)."""
+        h = 3.5 * jnp.ones((grid.Ny, grid.Nx))
+        out = diff_op(h, kappa=1.0)
+        np.testing.assert_allclose(out[1:-1, 1:-1], 0.0, atol=1e-10)
+
+    def test_kappa_scales_linearly(self, diff_op, grid, rng=None):
+        """Doubling κ doubles the tendency."""
+        key = jax.random.PRNGKey(0)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        t1 = diff_op(h, kappa=1.0)
+        t2 = diff_op(h, kappa=2.0)
+        np.testing.assert_allclose(t2[1:-1, 1:-1], 2.0 * t1[1:-1, 1:-1], rtol=1e-10)
+
+    def test_zero_tendency_for_zero_kappa(self, diff_op, grid):
+        key = jax.random.PRNGKey(1)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        out = diff_op(h, kappa=0.0)
+        np.testing.assert_allclose(out, 0.0, atol=1e-12)
+
+    def test_matches_cartesian_at_narrow_equatorial_band(self):
+        """At the equator with a very thin lat band, cos(lat) ≈ 1 and the
+        spherical operator reduces to the Cartesian flux-form diffusion
+        with dx = R·dlon, dy = R·dlat."""
+        nx, ny = 20, 6
+        lon_range = (0.0, 20.0)  # small so dlon is small
+        lat_range = (-0.5, 0.5)  # very narrow band around equator
+        sphere = SphericalGrid2D.from_interior(
+            nx_interior=nx,
+            ny_interior=ny,
+            lon_range=lon_range,
+            lat_range=lat_range,
+            R=R,
+        )
+        cart = CartesianGrid2D.from_interior(
+            nx_interior=nx,
+            ny_interior=ny,
+            Lx=sphere.Lx,
+            Ly=sphere.Ly,
+        )
+        key = jax.random.PRNGKey(3)
+        h = jax.random.normal(key, (sphere.Ny, sphere.Nx))
+
+        sph_op = SphericalDiffusion2D(grid=sphere)
+        cart_op = Diffusion2D(grid=cart)
+
+        t_sph = sph_op(h, kappa=1.0)
+        t_cart = cart_op(h, kappa=1.0)
+
+        # The two should agree to a few tolerance digits because cos(lat)
+        # deviates from 1 by O(1e-4) across a 1-degree lat band.
+        np.testing.assert_allclose(
+            t_sph[1:-1, 1:-1],
+            t_cart[1:-1, 1:-1],
+            rtol=5e-4,
+            atol=1e-4,
+        )
+
+    def test_fluxes_shape(self, diff_op, grid):
+        h = jnp.ones((grid.Ny, grid.Nx))
+        fx, fy = diff_op.fluxes(h, kappa=1.0)
+        assert fx.shape == (grid.Ny, grid.Nx)
+        assert fy.shape == (grid.Ny, grid.Nx)
+
+    def test_fluxes_constant_zero(self, diff_op, grid):
+        h = 5.0 * jnp.ones((grid.Ny, grid.Nx))
+        fx, fy = diff_op.fluxes(h, kappa=1.0)
+        # Constant tracer → zero flux everywhere.
+        np.testing.assert_allclose(fx, 0.0, atol=1e-12)
+        np.testing.assert_allclose(fy, 0.0, atol=1e-12)
+
+    def test_fluxes_boundary_faces_zero(self, diff_op, grid):
+        """East and north domain-wall faces are not written."""
+        key = jax.random.PRNGKey(4)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        fx, fy = diff_op.fluxes(h, kappa=1.0)
+        np.testing.assert_allclose(fx[:, -1], 0.0)  # east wall
+        np.testing.assert_allclose(fx[:, -2], 0.0)  # east-wall face (not written)
+        np.testing.assert_allclose(fx[0, :], 0.0)
+        np.testing.assert_allclose(fx[-1, :], 0.0)
+        np.testing.assert_allclose(fy[-1, :], 0.0)
+        np.testing.assert_allclose(fy[-2, :], 0.0)
+
+    def test_jit(self, diff_op, grid):
+        key = jax.random.PRNGKey(5)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        out = jax.jit(diff_op.__call__)(h, 1.0)
+        assert out.shape == (grid.Ny, grid.Nx)
+
+    def test_grad(self, diff_op, grid):
+        key = jax.random.PRNGKey(6)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        g = jax.grad(lambda x: diff_op(x, kappa=1.0).sum())(h)
+        assert g.shape == h.shape
+        assert jnp.all(jnp.isfinite(g))
+
+
+# ======================================================================
+# Masking
+# ======================================================================
+
+
+class TestSphericalDiffusion2DMasked:
+    def test_all_dry_mask_zeros_tendency(self, grid):
+        all_dry = Mask2D.from_mask(np.zeros((grid.Ny, grid.Nx), dtype=bool))
+        op = SphericalDiffusion2D(grid=grid, mask=all_dry)
+        key = jax.random.PRNGKey(7)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        out = op(h, kappa=1.0)
+        np.testing.assert_allclose(out, 0.0, atol=1e-12)
+
+    def test_all_wet_mask_matches_unmasked(self, grid):
+        all_wet = Mask2D.from_mask(np.ones((grid.Ny, grid.Nx), dtype=bool))
+        op_masked = SphericalDiffusion2D(grid=grid, mask=all_wet)
+        op_unmask = SphericalDiffusion2D(grid=grid)
+        key = jax.random.PRNGKey(8)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        np.testing.assert_allclose(
+            op_masked(h, kappa=1.0),
+            op_unmask(h, kappa=1.0),
+            atol=1e-12,
+        )
+
+    def test_dry_cell_zero(self, grid):
+        """A dry T-cell has zero tendency in the masked tendency."""
+        mask = np.ones((grid.Ny, grid.Nx), dtype=bool)
+        mask[3, 5] = False  # make an interior cell dry
+        op = SphericalDiffusion2D(grid=grid, mask=Mask2D.from_mask(mask))
+        key = jax.random.PRNGKey(9)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        out = op(h, kappa=1.0)
+        assert float(out[3, 5]) == 0.0
+
+
+# ======================================================================
+# SphericalDiffusion3D
+# ======================================================================
+
+
+class TestSphericalDiffusion3D:
+    def test_output_shape(self, diff_op3d, grid3d):
+        h = jnp.ones((grid3d.Nz, grid3d.Ny, grid3d.Nx))
+        out = diff_op3d(h, kappa=1.0)
+        assert out.shape == (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+
+    def test_constant_tracer_zero(self, diff_op3d, grid3d):
+        h = 2.0 * jnp.ones((grid3d.Nz, grid3d.Ny, grid3d.Nx))
+        out = diff_op3d(h, kappa=1.0)
+        np.testing.assert_allclose(out[:, 1:-1, 1:-1], 0.0, atol=1e-10)
+
+    def test_z_ghost_slices_zero(self, diff_op3d, grid3d):
+        key = jax.random.PRNGKey(10)
+        h = jax.random.normal(key, (grid3d.Nz, grid3d.Ny, grid3d.Nx))
+        out = diff_op3d(h, kappa=1.0)
+        np.testing.assert_allclose(out[0, :, :], 0.0, atol=1e-10)
+        np.testing.assert_allclose(out[-1, :, :], 0.0, atol=1e-10)
+
+    def test_matches_2d_per_level(self, diff_op3d, grid3d):
+        """Applying SphericalDiffusion3D on a z-broadcast field should
+        equal the 2-D operator at each interior level."""
+        op2d = SphericalDiffusion2D(grid=grid3d.horizontal_grid())
+        key = jax.random.PRNGKey(11)
+        h_2d = jax.random.normal(key, (grid3d.Ny, grid3d.Nx))
+        h_3d = jnp.broadcast_to(h_2d, (grid3d.Nz, grid3d.Ny, grid3d.Nx))
+
+        t_2d = op2d(h_2d, kappa=1.0)
+        t_3d = diff_op3d(h_3d, kappa=1.0)
+
+        for k in range(1, grid3d.Nz - 1):
+            np.testing.assert_allclose(t_3d[k], t_2d, atol=1e-12)
+
+    def test_masked_all_dry_zero(self, grid3d):
+        all_dry = Mask3D.from_mask(
+            np.zeros((grid3d.Nz, grid3d.Ny, grid3d.Nx), dtype=bool)
+        )
+        op = SphericalDiffusion3D(grid=grid3d, mask=all_dry)
+        key = jax.random.PRNGKey(12)
+        h = jax.random.normal(key, (grid3d.Nz, grid3d.Ny, grid3d.Nx))
+        out = op(h, kappa=1.0)
+        np.testing.assert_allclose(out, 0.0, atol=1e-12)
+
+    def test_masked_all_wet_matches_unmasked(self, grid3d):
+        all_wet = Mask3D.from_mask(
+            np.ones((grid3d.Nz, grid3d.Ny, grid3d.Nx), dtype=bool)
+        )
+        op_m = SphericalDiffusion3D(grid=grid3d, mask=all_wet)
+        op_u = SphericalDiffusion3D(grid=grid3d)
+        key = jax.random.PRNGKey(13)
+        h = jax.random.normal(key, (grid3d.Nz, grid3d.Ny, grid3d.Nx))
+        np.testing.assert_allclose(op_m(h, 1.0), op_u(h, 1.0), atol=1e-12)
+
+    def test_fluxes_shape(self, diff_op3d, grid3d):
+        h = jnp.ones((grid3d.Nz, grid3d.Ny, grid3d.Nx))
+        fx, fy = diff_op3d.fluxes(h, kappa=1.0)
+        assert fx.shape == (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+        assert fy.shape == (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+
+    def test_jit_grad(self, diff_op3d, grid3d):
+        key = jax.random.PRNGKey(14)
+        h = jax.random.normal(key, (grid3d.Nz, grid3d.Ny, grid3d.Nx))
+        jitted = jax.jit(diff_op3d.__call__)
+        out = jitted(h, 1.0)
+        assert out.shape == h.shape
+        g = jax.grad(lambda x: diff_op3d(x, 1.0).sum())(h)
+        assert g.shape == h.shape
+        assert jnp.all(jnp.isfinite(g))

--- a/tests/test_spherical_diffusion.py
+++ b/tests/test_spherical_diffusion.py
@@ -82,7 +82,7 @@ class TestSphericalDiffusion2D:
         out = diff_op(h, kappa=1.0)
         np.testing.assert_allclose(out[1:-1, 1:-1], 0.0, atol=1e-10)
 
-    def test_kappa_scales_linearly(self, diff_op, grid, rng=None):
+    def test_kappa_scales_linearly(self, diff_op, grid):
         """Doubling κ doubles the tendency."""
         key = jax.random.PRNGKey(0)
         h = jax.random.normal(key, (grid.Ny, grid.Nx))


### PR DESCRIPTION
## Summary

Adds spherical-coordinate harmonic diffusion and tracer advection operators to complete **Phase 5** of the spherical operator programme (#162). Closes #165.

- `SphericalDiffusion2D/3D` — flux-form ∂h/∂t = ∇·(κ∇h) with metric-aware staggered fluxes and the same three-step intermediate-flux masking pattern as the Cartesian counterpart
- `SphericalAdvection2D/3D` — ∂h/∂t = −∇·(h·u_vec) with spherical flux divergence; the full Cartesian reconstruction menu (upwind 1/2/3, WENO3/5/7/9, WENOz5, TVD with minmod/van_leer/superbee/mc) works unchanged since those stencils are coordinate-agnostic
- `Reconstruction1D/2D/3D.grid` annotation relaxed `CartesianGridND → ArakawaCGridND` (the reconstructors never read grid-spacing fields, so this is a pure annotation fix)

## Details

**Diffusion** (`finitevolx/_src/diffusion/spherical_diffusion.py`)
- Stencil: `F_λ = κ·(h[j,i+1]−h[j,i])/(R·cos(lat_U)·dlon)` at U-points, `F_φ = κ·(h[j+1,i]−h[j,i])/(R·dlat)` at V-points, then spherical flux-divergence with `cos(lat_V)` weight on the meridional terms and `1/(R·cos(lat_T))` outer scale
- Reduces bit-for-bit to `Diffusion2D` at the equator (cos=1)
- Pole guard via `_safe_div_cos` → NaN where |cos(lat)| < 1e-12
- Masking: intermediate flux × `mask.u` / `mask.v`, tendency × `mask.h` (same rationale as `Diffusion2D` per #209)
- `fluxes()` diagnostic accessor returns (F_λ, F_φ)

**Advection** (`finitevolx/_src/advection/spherical_advection.py`)
- Reuses `Reconstruction2D/3D` directly for face-flux reconstruction (all methods supported)
- Spherical divergence: `−(1/(R·cos(lat_T)))·[(fe[j,i]−fe[j,i−1])/dlon + (cos_V_N·fn[j,i] − cos_V_S·fn[j−1,i])/dlat]` written to interior `[2:-2, 2:-2]` (matching `Advection2D` convention)
- Same mask-adaptive stencil hierarchy for WENO/TVD dispatchable methods; post-compute `* mask.h` for the rest

## Public API additions

```python
SphericalDiffusion2D, SphericalDiffusion3D
SphericalAdvection2D, SphericalAdvection3D
```

## Test plan

- [x] 22 tests in `test_spherical_diffusion.py` (shapes, ghost-ring zero, constant-tracer invariance, kappa linearity, equatorial limit vs `Diffusion2D`, all-dry/all-wet/per-cell masking, JIT, grad, 3-D broadcast consistency)
- [x] 27 tests in `test_spherical_advection.py` (shapes, zero-velocity zero tendency, all reconstruction methods produce finite output, ghost-ring zero, equatorial limit vs `Advection2D` for upwind1/weno3/weno5, all-dry/all-wet/per-cell masking, JIT, grad, 3-D broadcast consistency)
- [x] Full suite: **1885 tests pass**
- [x] `ruff check .`, `ruff format --check .`, `ty check finitevolx` — all clean