### PR TITLE
feat: spherical follow-ups — biharmonic, momentum advection, reductions

### DIFF
--- a/finitevolx/__init__.py
+++ b/finitevolx/__init__.py
@@ -74,8 +74,14 @@ from finitevolx._src.diffusion.diffusion import (
 )
 from finitevolx._src.diffusion.momentum import MomentumAdvection2D, MomentumAdvection3D
 from finitevolx._src.diffusion.spherical_diffusion import (
+    SphericalBiharmonicDiffusion2D,
+    SphericalBiharmonicDiffusion3D,
     SphericalDiffusion2D,
     SphericalDiffusion3D,
+)
+from finitevolx._src.diffusion.spherical_momentum import (
+    SphericalMomentumAdvection2D,
+    SphericalMomentumAdvection3D,
 )
 from finitevolx._src.grid.base import (
     ArakawaCGrid1D,
@@ -142,6 +148,26 @@ from finitevolx._src.operators.interpolation import (
     Interpolation3D,
 )
 from finitevolx._src.operators.jacobian import arakawa_jacobian
+from finitevolx._src.operators.reductions import (
+    area_mean,
+    area_sum,
+    area_weights,
+    cartesian_area_mean,
+    cartesian_area_sum,
+    cartesian_area_weights,
+    cartesian_volume_mean,
+    cartesian_volume_sum,
+    cartesian_volume_weights,
+    spherical_area_mean,
+    spherical_area_sum,
+    spherical_area_weights,
+    spherical_volume_mean,
+    spherical_volume_sum,
+    spherical_volume_weights,
+    volume_mean,
+    volume_sum,
+    volume_weights,
+)
 from finitevolx._src.operators.spherical_compound import (
     SphericalDivergence2D,
     SphericalDivergence3D,
@@ -379,8 +405,29 @@ __all__ = [
     # Momentum advection
     "MomentumAdvection2D",
     "MomentumAdvection3D",
+    "SphericalMomentumAdvection2D",
+    "SphericalMomentumAdvection3D",
     # Jacobian
     "arakawa_jacobian",
+    # Area- and volume-weighted reductions (grid-polymorphic + explicit)
+    "area_weights",
+    "area_sum",
+    "area_mean",
+    "volume_weights",
+    "volume_sum",
+    "volume_mean",
+    "cartesian_area_weights",
+    "cartesian_area_sum",
+    "cartesian_area_mean",
+    "cartesian_volume_weights",
+    "cartesian_volume_sum",
+    "cartesian_volume_mean",
+    "spherical_area_weights",
+    "spherical_area_sum",
+    "spherical_area_mean",
+    "spherical_volume_weights",
+    "spherical_volume_sum",
+    "spherical_volume_mean",
     # Multilayer vmap helper
     "multilayer",
     # Grid — abstract topology
@@ -453,6 +500,8 @@ __all__ = [
     "BiharmonicDiffusion3D",
     "Diffusion2D",
     "Diffusion3D",
+    "SphericalBiharmonicDiffusion2D",
+    "SphericalBiharmonicDiffusion3D",
     "SphericalDiffusion2D",
     "SphericalDiffusion3D",
     "diffusion_2d",

--- a/finitevolx/_src/diffusion/spherical_diffusion.py
+++ b/finitevolx/_src/diffusion/spherical_diffusion.py
@@ -396,3 +396,171 @@ class SphericalDiffusion3D(eqx.Module):
             h, kappa_arr, mu, mv
         )
         return zero_z_ghosts(fx), zero_z_ghosts(fy)
+
+
+class SphericalBiharmonicDiffusion2D(eqx.Module):
+    """Biharmonic (spherical ∇⁴) diffusion on a 2-D spherical C-grid.
+
+    Computes the scale-selective biharmonic tendency
+
+        ∂h/∂t|_diff = −κ · ∇⁴_sphere h
+
+    where ``∇⁴_sphere h = ∇²_sphere(∇²_sphere h)`` is implemented as
+    two successive flux-form spherical Laplacians via
+    :class:`SphericalDiffusion2D`.  Positive κ gives dissipation, with
+    small-scale damping scaling as ``κ·k⁴`` vs ``κ·k²`` for harmonic
+    diffusion — the standard scale-selective mixing used in MITgcm,
+    MOM, and other GCMs on spherical grids.
+
+    Only interior cells ``[1:-1, 1:-1]`` are written; the ghost ring
+    is zero.  The caller is responsible for boundary conditions.
+
+    Parameters
+    ----------
+    grid : SphericalGrid2D
+        The underlying 2-D spherical grid.
+    mask : Mask2D or None, optional
+        Optional land/ocean mask.  When provided, the inner harmonic
+        :class:`SphericalDiffusion2D` is deliberately built with
+        ``mask=None`` — masking the intermediate Laplacian would
+        corrupt the second harmonic pass because ``lap1 == 0`` at dry
+        T-cells becomes a forced zero-Dirichlet boundary for the
+        second pass, which distorts the ∇⁴ stencil at wet cells
+        adjacent to land.  Instead, the mask is applied via a
+        post-compute ``* mask.h`` on the **final** ``−κ · ∇⁴h``
+        tendency only.  This is the design exception called out in
+        issue #209 §4, identical to :class:`BiharmonicDiffusion2D`.
+
+    Notes
+    -----
+    The ghost ring of the intermediate Laplacian ``∇²_sphere h`` is
+    zero (Dirichlet-0), not zero-normal-gradient (Neumann).  The
+    second pass reads a zero halo for the intermediate field, which
+    contaminates the outermost interior row/column of the final
+    tendency — only results in the deep interior ``[2:-2, 2:-2]`` are
+    fully BC-consistent.  Same caveat as :class:`BiharmonicDiffusion2D`.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> from finitevolx import SphericalGrid2D, SphericalBiharmonicDiffusion2D
+    >>> grid = SphericalGrid2D.from_interior(
+    ...     nx_interior=16,
+    ...     ny_interior=10,
+    ...     lon_range=(0.0, 360.0),
+    ...     lat_range=(-40.0, 40.0),
+    ... )
+    >>> op = SphericalBiharmonicDiffusion2D(grid=grid)
+    >>> h = jnp.ones((grid.Ny, grid.Nx))
+    >>> tend = op(h, kappa=1e6)
+    >>> tend.shape
+    (12, 18)
+    """
+
+    grid: SphericalGrid2D
+    mask: Mask2D | None
+    _harm: SphericalDiffusion2D
+
+    def __init__(
+        self,
+        grid: SphericalGrid2D,
+        mask: Mask2D | None = None,
+    ) -> None:
+        self.grid = grid
+        self.mask = mask
+        # Critical: inner harmonic operator is ALWAYS mask=None, even when
+        # SphericalBiharmonicDiffusion2D has a mask.  See class docstring.
+        self._harm = SphericalDiffusion2D(grid=grid)
+
+    def __call__(
+        self,
+        h: Float[Array, "Ny Nx"],
+        kappa: float,
+    ) -> Float[Array, "Ny Nx"]:
+        """Apply biharmonic diffusion and return ``−κ · ∇⁴_sphere h``.
+
+        Parameters
+        ----------
+        h : Float[Array, "Ny Nx"]
+            Scalar tracer at T-points.
+        kappa : float
+            Biharmonic diffusion coefficient (κ ≥ 0 gives dissipation).
+
+        Returns
+        -------
+        Float[Array, "Ny Nx"]
+            Tendency ``−κ · ∇⁴_sphere h`` at T-points, same shape as
+            ``h``.  Ghost cells are zero.  When ``self.mask`` is set,
+            the output is post-multiplied by ``mask.h``.
+        """
+        lap1 = self._harm(h, kappa=1.0)
+        lap2 = self._harm(lap1, kappa=1.0)
+        out = -kappa * lap2
+        if self.mask is not None:
+            out = out * self.mask.h
+        return out
+
+
+class SphericalBiharmonicDiffusion3D(eqx.Module):
+    """Biharmonic spherical diffusion on a 3-D Arakawa C-grid.
+
+    Applies the horizontal biharmonic spherical Laplacian independently
+    at each z-level
+
+        ∂h/∂t|_diff = −κ · ∇⁴_{h,sphere} h
+
+    where ``∇⁴_{h,sphere}`` denotes the horizontal spherical biharmonic
+    operator, implemented as two successive :class:`SphericalDiffusion3D`
+    passes.
+
+    Parameters
+    ----------
+    grid : SphericalGrid3D
+    mask : Mask3D or None, optional
+        Optional 3-D land/ocean mask.  The inner harmonic
+        :class:`SphericalDiffusion3D` is always built with
+        ``mask=None``; the outer mask is applied as a post-compute
+        ``* mask.h`` on the final tendency — same exception as
+        :class:`SphericalBiharmonicDiffusion2D`.
+    """
+
+    grid: SphericalGrid3D
+    mask: Mask3D | None
+    _harm: SphericalDiffusion3D
+
+    def __init__(
+        self,
+        grid: SphericalGrid3D,
+        mask: Mask3D | None = None,
+    ) -> None:
+        self.grid = grid
+        self.mask = mask
+        self._harm = SphericalDiffusion3D(grid=grid)
+
+    def __call__(
+        self,
+        h: Float[Array, "Nz Ny Nx"],
+        kappa: float,
+    ) -> Float[Array, "Nz Ny Nx"]:
+        """Apply horizontal biharmonic spherical diffusion.
+
+        Parameters
+        ----------
+        h : Float[Array, "Nz Ny Nx"]
+            Scalar tracer at T-points.
+        kappa : float
+            Biharmonic diffusion coefficient (κ ≥ 0 gives dissipation).
+
+        Returns
+        -------
+        Float[Array, "Nz Ny Nx"]
+            Tendency ``−κ · ∇⁴_{h,sphere} h`` at T-points.  Ghost cells
+            are zero.  When ``self.mask`` is set, the output is
+            post-multiplied by ``mask.h``.
+        """
+        lap1 = self._harm(h, kappa=1.0)
+        lap2 = self._harm(lap1, kappa=1.0)
+        out = -kappa * lap2
+        if self.mask is not None:
+            out = out * self.mask.h
+        return out

--- a/finitevolx/_src/diffusion/spherical_momentum.py
+++ b/finitevolx/_src/diffusion/spherical_momentum.py
@@ -1,0 +1,281 @@
+"""Energy-conserving momentum advection operators on spherical C-grids.
+
+Spherical counterpart of :mod:`finitevolx._src.diffusion.momentum`.
+
+Uses the vector-invariant (vortex-force) form of the horizontal
+momentum equations:
+
+    du/dt|adv[j, i+½] = +(ζ·v)_u − ∂K/∂λ_spherical
+    dv/dt|adv[j+½, i] = −(ζ·u)_v − ∂K/∂φ_spherical
+
+where ``ζ`` is the spherical relative vorticity at X-points (NE
+corners), ``K = ½ (u_T² + v_T²)`` is the kinetic energy at T-points,
+and the vorticity-flux products (ζ·v) / (ζ·u) are computed with one of
+three discrete schemes (Sadourny E/Z, Arakawa–Lamb 1/3–2/3 blend).
+
+The three flux schemes are **coordinate-independent** — they involve
+only interpolation and multiplication.  What changes on a sphere is:
+
+* the curl is computed with :class:`SphericalVorticity2D`, which
+  applies the ``1/(R·cosφ)`` metric to ``∂v/∂λ − ∂(u·cosφ)/∂φ``;
+* the kinetic-energy gradients at U-/V-points use
+  :class:`SphericalDifference2D` so ``∂K/∂λ`` picks up
+  ``1/(R·cos(lat_U))`` and ``∂K/∂φ`` picks up ``1/R``.
+
+At the equator (``cos(lat) = 1``) the spherical operator reduces to
+the Cartesian :class:`~finitevolx.MomentumAdvection2D` with
+``dx = R·dlon`` and ``dy = R·dlat``.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+from jaxtyping import Array, Float
+
+from finitevolx._src.grid.spherical import SphericalGrid2D, SphericalGrid3D
+from finitevolx._src.mask import Mask2D, Mask3D
+from finitevolx._src.operators._ghost import interior, zero_z_ghosts
+from finitevolx._src.operators.interpolation import Interpolation2D
+from finitevolx._src.operators.spherical_compound import SphericalVorticity2D
+from finitevolx._src.operators.spherical_difference import SphericalDifference2D
+
+
+class SphericalMomentumAdvection2D(eqx.Module):
+    """Energy-conserving momentum advection on a 2-D spherical C-grid.
+
+    Computes the vortex-force form on a sphere:
+
+        du/dt|adv[j, i+½] = +(ζ·v)_u − ∂K/∂λ_spherical
+        dv/dt|adv[j+½, i] = −(ζ·u)_v − ∂K/∂φ_spherical
+
+    where ``ζ = 1/(R·cosφ)·[∂v/∂λ − ∂(u·cosφ)/∂φ]`` at X-points and
+    ``K = ½(u_T² + v_T²)`` at T-points.
+
+    Three vorticity-flux schemes are available via the ``scheme`` argument:
+
+    * ``'energy'`` — Sadourny (1975) **E-scheme**: interpolate ζ to faces
+      first, then multiply by the cross-face velocity.
+    * ``'enstrophy'`` — Sadourny (1975) **Z-scheme**: interpolate the
+      velocity to corners, multiply by ζ at corners, then interpolate the
+      product to faces.
+    * ``'al'`` — **Arakawa-Lamb (1981)** blend: ⅓ energy + ⅔ enstrophy.
+
+    Parameters
+    ----------
+    grid : SphericalGrid2D
+        The underlying 2-D spherical grid.
+    mask : Mask2D or None, optional
+        Optional land/ocean mask.  Pass-down pattern — the internal
+        :class:`SphericalDifference2D` (for ``∂K/∂λ``, ``∂K/∂φ``),
+        :class:`Interpolation2D` (for the vorticity-flux averages and
+        ``u_T``/``v_T``), and :class:`SphericalVorticity2D` (for ``ζ``)
+        are constructed with the same mask, so every intermediate
+        staggered field carries the correct post-compute zero.  The
+        final tendencies are additionally post-multiplied by
+        ``mask.u`` / ``mask.v``.  Per #209 Q2 a Cartesian ``Mask2D`` is
+        used pending a dedicated ``SphericalMask2D`` follow-up.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> from finitevolx import SphericalGrid2D, SphericalMomentumAdvection2D
+    >>> grid = SphericalGrid2D.from_interior(
+    ...     nx_interior=16,
+    ...     ny_interior=8,
+    ...     lon_range=(0.0, 360.0),
+    ...     lat_range=(-40.0, 40.0),
+    ... )
+    >>> madv = SphericalMomentumAdvection2D(grid=grid)
+    >>> u = jnp.zeros((grid.Ny, grid.Nx))
+    >>> v = jnp.zeros((grid.Ny, grid.Nx))
+    >>> du, dv = madv(u, v)
+    """
+
+    grid: SphericalGrid2D
+    mask: Mask2D | None
+    diff: SphericalDifference2D
+    interp: Interpolation2D
+    vort: SphericalVorticity2D
+
+    def __init__(
+        self,
+        grid: SphericalGrid2D,
+        mask: Mask2D | None = None,
+    ) -> None:
+        self.grid = grid
+        self.mask = mask
+        self.diff = SphericalDifference2D(grid=grid, mask=mask)
+        self.interp = Interpolation2D(grid=grid, mask=mask)
+        self.vort = SphericalVorticity2D(grid=grid, mask=mask)
+
+    def _kinetic_energy_gradients(
+        self,
+        u: Float[Array, "Ny Nx"],
+        v: Float[Array, "Ny Nx"],
+    ) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
+        """Spherical KE gradients (∂K/∂λ at U-points, ∂K/∂φ at V-points).
+
+        K[j, i] = ½ (u_T² + v_T²)   at T-points
+        ∂K/∂λ[j, i+½] = (K[j, i+1] − K[j, i]) / (R · cos(lat_U) · dlon)
+        ∂K/∂φ[j+½, i] = (K[j+1, i] − K[j, i]) / (R · dlat)
+        """
+        u_on_T = self.interp.U_to_T(u)
+        v_on_T = self.interp.V_to_T(v)
+        K = interior(0.5 * (u_on_T[1:-1, 1:-1] ** 2 + v_on_T[1:-1, 1:-1] ** 2), u)
+        return self.diff.diff_lon_T_to_U(K), self.diff.diff_lat_T_to_V(K)
+
+    def _vorticity_flux_energy(
+        self,
+        zeta: Float[Array, "Ny Nx"],
+        u: Float[Array, "Ny Nx"],
+        v: Float[Array, "Ny Nx"],
+    ) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
+        """Sadourny E-scheme vorticity flux at (U-points, V-points)."""
+        zeta_on_u = self.interp.X_to_U(zeta)
+        zeta_on_v = self.interp.X_to_V(zeta)
+        v_on_u = self.interp.V_to_U(v)
+        u_on_v = self.interp.U_to_V(u)
+        zv_u = interior(zeta_on_u[1:-1, 1:-1] * v_on_u[1:-1, 1:-1], u)
+        zu_v = interior(zeta_on_v[1:-1, 1:-1] * u_on_v[1:-1, 1:-1], v)
+        return zv_u, zu_v
+
+    def _vorticity_flux_enstrophy(
+        self,
+        zeta: Float[Array, "Ny Nx"],
+        u: Float[Array, "Ny Nx"],
+        v: Float[Array, "Ny Nx"],
+    ) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
+        """Sadourny Z-scheme vorticity flux at (U-points, V-points)."""
+        v_on_q = self.interp.V_to_X(v)
+        u_on_q = self.interp.U_to_X(u)
+        zv_at_q = interior(zeta[1:-1, 1:-1] * v_on_q[1:-1, 1:-1], u)
+        zu_at_q = interior(zeta[1:-1, 1:-1] * u_on_q[1:-1, 1:-1], v)
+        return self.interp.X_to_U(zv_at_q), self.interp.X_to_V(zu_at_q)
+
+    def __call__(
+        self,
+        u: Float[Array, "Ny Nx"],
+        v: Float[Array, "Ny Nx"],
+        scheme: str = "energy",
+    ) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
+        """Momentum advection tendencies on a sphere.
+
+        Parameters
+        ----------
+        u : Float[Array, "Ny Nx"]
+            Zonal velocity at U-points.
+        v : Float[Array, "Ny Nx"]
+            Meridional velocity at V-points.
+        scheme : str
+            Vorticity-flux scheme: ``'energy'`` (default), ``'enstrophy'``,
+            or ``'al'`` (Arakawa-Lamb blend).
+
+        Returns
+        -------
+        tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]
+            ``(du_adv, dv_adv)`` — tendencies at U- and V-points, zero
+            in the ghost ring.
+
+        Raises
+        ------
+        ValueError
+            If ``scheme`` is not one of ``'energy'``, ``'enstrophy'``,
+            or ``'al'``.
+        """
+        zeta = self.vort.relative_vorticity(u, v)
+        dK_dlon, dK_dlat = self._kinetic_energy_gradients(u, v)
+
+        if scheme == "energy":
+            zv_u, zu_v = self._vorticity_flux_energy(zeta, u, v)
+        elif scheme == "enstrophy":
+            zv_u, zu_v = self._vorticity_flux_enstrophy(zeta, u, v)
+        elif scheme == "al":
+            alpha = 1.0 / 3.0
+            zv_u_e, zu_v_e = self._vorticity_flux_energy(zeta, u, v)
+            zv_u_s, zu_v_s = self._vorticity_flux_enstrophy(zeta, u, v)
+            zv_u = interior(
+                alpha * zv_u_e[1:-1, 1:-1] + (1.0 - alpha) * zv_u_s[1:-1, 1:-1], u
+            )
+            zu_v = interior(
+                alpha * zu_v_e[1:-1, 1:-1] + (1.0 - alpha) * zu_v_s[1:-1, 1:-1], v
+            )
+        else:
+            raise ValueError(
+                f"Unknown scheme: {scheme!r}.  Choose 'energy', 'enstrophy', or 'al'."
+            )
+
+        # du_adv at U[j, i+1/2] = +(zeta * v)_u - dK/dlon
+        du_adv = interior(zv_u[2:-2, 2:-2] - dK_dlon[2:-2, 2:-2], u, ghost=2)
+        # dv_adv at V[j+1/2, i] = -(zeta * u)_v - dK/dlat
+        dv_adv = interior(-zu_v[2:-2, 2:-2] - dK_dlat[2:-2, 2:-2], v, ghost=2)
+
+        if self.mask is not None:
+            du_adv = du_adv * self.mask.u
+            dv_adv = dv_adv * self.mask.v
+        return du_adv, dv_adv
+
+
+class SphericalMomentumAdvection3D(eqx.Module):
+    """Energy-conserving momentum advection on a 3-D spherical C-grid.
+
+    Applies :class:`SphericalMomentumAdvection2D`-equivalent stencils
+    independently at each z-level of a ``[Nz, Ny, Nx]`` array.  The
+    output write region is ``[1:-1, 2:-2, 2:-2]`` (all interior z-levels,
+    strict horizontal interior), matching the 3-D advection convention.
+
+    Parameters
+    ----------
+    grid : SphericalGrid3D
+    mask : Mask3D or None, optional
+        Optional 3-D land/ocean mask.  Pattern A (post-compute) — the
+        inner :class:`SphericalMomentumAdvection2D` is always built
+        ``mask=None`` and the vmap'd 3-D result is post-multiplied by
+        ``mask.u`` / ``mask.v``.
+    """
+
+    grid: SphericalGrid3D
+    mask: Mask3D | None
+    _madv2d: SphericalMomentumAdvection2D
+
+    def __init__(
+        self,
+        grid: SphericalGrid3D,
+        mask: Mask3D | None = None,
+    ) -> None:
+        self.grid = grid
+        self.mask = mask
+        self._madv2d = SphericalMomentumAdvection2D(grid=grid.horizontal_grid())
+
+    def __call__(
+        self,
+        u: Float[Array, "Nz Ny Nx"],
+        v: Float[Array, "Nz Ny Nx"],
+        scheme: str = "energy",
+    ) -> tuple[Float[Array, "Nz Ny Nx"], Float[Array, "Nz Ny Nx"]]:
+        """Spherical momentum advection tendencies over all z-levels.
+
+        Parameters
+        ----------
+        u : Float[Array, "Nz Ny Nx"]
+            Zonal velocity at U-points.
+        v : Float[Array, "Nz Ny Nx"]
+            Meridional velocity at V-points.
+        scheme : str
+            Vorticity-flux scheme: ``'energy'`` (default), ``'enstrophy'``,
+            or ``'al'``.
+
+        Returns
+        -------
+        tuple[Float[Array, "Nz Ny Nx"], Float[Array, "Nz Ny Nx"]]
+            ``(du_adv, dv_adv)`` at U- and V-points; zero at z-ghost
+            slices and at outermost horizontal ring.
+        """
+        du_adv, dv_adv = eqx.filter_vmap(
+            lambda u_k, v_k: self._madv2d(u_k, v_k, scheme=scheme)
+        )(u, v)
+        du_adv = zero_z_ghosts(du_adv)
+        dv_adv = zero_z_ghosts(dv_adv)
+        if self.mask is not None:
+            du_adv = du_adv * self.mask.u
+            dv_adv = dv_adv * self.mask.v
+        return du_adv, dv_adv

--- a/finitevolx/_src/operators/reductions.py
+++ b/finitevolx/_src/operators/reductions.py
@@ -1,0 +1,364 @@
+"""
+Area- and volume-weighted reduction helpers for Arakawa C-grids.
+
+Provides scalar totals and means of T-point fields that account for
+the correct per-cell metric on Cartesian and spherical grids:
+
+    Cartesian T-cell area  = dx · dy
+    Spherical T-cell area  = R² · cos(lat_T) · dlon · dlat
+    3-D T-cell volume      = area · dz
+
+Only physical interior cells contribute — the ghost ring is excluded
+by construction.  When a mask is supplied, dry cells are excluded from
+both the numerator and the denominator of ``*_mean``.
+
+The polymorphic dispatchers :func:`area_sum`, :func:`area_mean`,
+:func:`volume_sum`, :func:`volume_mean` choose the right metric at
+runtime based on the grid type, so user code can stay grid-agnostic.
+
+Example
+-------
+>>> from finitevolx import area_sum, SphericalGrid2D
+>>> grid = SphericalGrid2D.from_interior(64, 32, (0.0, 360.0), (-80.0, 80.0))
+>>> h = jnp.ones((grid.Ny, grid.Nx))
+>>> total = area_sum(h, grid)  # integrated tracer over the basin
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from finitevolx._src.grid.base import (
+    ArakawaCGrid2D,
+    ArakawaCGrid3D,
+)
+from finitevolx._src.grid.cartesian import CartesianGrid2D, CartesianGrid3D
+from finitevolx._src.grid.spherical import SphericalGrid2D, SphericalGrid3D
+from finitevolx._src.mask import Mask2D, Mask3D
+
+# ----------------------------------------------------------------------
+# Cell-area / cell-volume metrics
+# ----------------------------------------------------------------------
+
+
+def cartesian_area_weights(grid: CartesianGrid2D) -> Float[Array, "Ny Nx"]:
+    """T-cell areas on a Cartesian grid.
+
+    ``A[j, i] = dx · dy`` broadcast to the grid shape.
+
+    Parameters
+    ----------
+    grid : CartesianGrid2D
+
+    Returns
+    -------
+    Float[Array, "Ny Nx"]
+        Per-cell area, constant everywhere.
+    """
+    return jnp.full((grid.Ny, grid.Nx), grid.dx * grid.dy)
+
+
+def spherical_area_weights(grid: SphericalGrid2D) -> Float[Array, "Ny Nx"]:
+    """T-cell areas on a spherical grid.
+
+    ``A[j, i] = R² · cos(lat_T[j, i]) · dlon · dlat``.
+
+    Near the poles (``|cos(lat_T)| < 1e-12``) the weight is taken as
+    zero rather than a tiny positive number to avoid near-singular
+    denominators in ``*_mean``.
+
+    Parameters
+    ----------
+    grid : SphericalGrid2D
+
+    Returns
+    -------
+    Float[Array, "Ny Nx"]
+        Per-T-cell area.
+    """
+    cos_T = grid.cos_lat_T
+    base = grid.R**2 * grid.dlon * grid.dlat
+    weights = base * cos_T
+    return jnp.where(jnp.abs(cos_T) < 1e-12, 0.0, weights)
+
+
+def area_weights(grid: ArakawaCGrid2D) -> Float[Array, "Ny Nx"]:
+    """Dispatch to :func:`cartesian_area_weights` or :func:`spherical_area_weights`.
+
+    Parameters
+    ----------
+    grid : ArakawaCGrid2D
+        A concrete 2-D grid (Cartesian or spherical).
+
+    Returns
+    -------
+    Float[Array, "Ny Nx"]
+        Per-T-cell area on the supplied grid.
+
+    Raises
+    ------
+    TypeError
+        If the grid type is not recognized.
+    """
+    if isinstance(grid, SphericalGrid2D):
+        return spherical_area_weights(grid)
+    if isinstance(grid, CartesianGrid2D):
+        return cartesian_area_weights(grid)
+    raise TypeError(
+        f"area_weights: unsupported grid type {type(grid).__name__}. "
+        "Use CartesianGrid2D or SphericalGrid2D."
+    )
+
+
+def cartesian_volume_weights(grid: CartesianGrid3D) -> Float[Array, "Nz Ny Nx"]:
+    """T-cell volumes on a Cartesian 3-D grid: ``dx · dy · dz``."""
+    return jnp.full((grid.Nz, grid.Ny, grid.Nx), grid.dx * grid.dy * grid.dz)
+
+
+def spherical_volume_weights(grid: SphericalGrid3D) -> Float[Array, "Nz Ny Nx"]:
+    """T-cell volumes on a spherical 3-D grid.
+
+    ``V[k, j, i] = R² · cos(lat_T[j, i]) · dlon · dlat · dz`` — the
+    horizontal area broadcast over z, times the uniform vertical
+    thickness.
+    """
+    area_2d = spherical_area_weights(grid.horizontal_grid())
+    return jnp.broadcast_to(area_2d * grid.dz, (grid.Nz, grid.Ny, grid.Nx))
+
+
+def volume_weights(grid: ArakawaCGrid3D) -> Float[Array, "Nz Ny Nx"]:
+    """Dispatch to Cartesian/spherical volume weights based on grid type."""
+    if isinstance(grid, SphericalGrid3D):
+        return spherical_volume_weights(grid)
+    if isinstance(grid, CartesianGrid3D):
+        return cartesian_volume_weights(grid)
+    raise TypeError(
+        f"volume_weights: unsupported grid type {type(grid).__name__}. "
+        "Use CartesianGrid3D or SphericalGrid3D."
+    )
+
+
+# ----------------------------------------------------------------------
+# 2-D interior reductions
+# ----------------------------------------------------------------------
+
+
+def _interior_2d(field: Float[Array, "Ny Nx"]) -> Float[Array, "Ny_i Nx_i"]:
+    """Slice physical interior (exclude 1-cell ghost ring)."""
+    return field[1:-1, 1:-1]
+
+
+def _mask_factor_2d(
+    mask: Mask2D | None,
+    grid: ArakawaCGrid2D,
+) -> Float[Array, "Ny Nx"]:
+    """Return a float mask for T-points (1.0 wet, 0.0 dry) or all-ones."""
+    if mask is None:
+        return jnp.ones((grid.Ny, grid.Nx))
+    return jnp.asarray(mask.h, dtype=jnp.float64)
+
+
+def area_sum(
+    field: Float[Array, "Ny Nx"],
+    grid: ArakawaCGrid2D,
+    mask: Mask2D | None = None,
+) -> Float[Array, ""]:
+    """Area-weighted sum over physical interior T-cells.
+
+    Computes ``Σ_j Σ_i A[j, i] · m[j, i] · field[j, i]`` where ``A``
+    is the per-cell area metric for the grid type (Cartesian or
+    spherical), ``m`` is the T-point wet/dry mask (1.0 wet, 0.0 dry)
+    when ``mask`` is supplied, and the sum is taken over the interior
+    ``[1:-1, 1:-1]`` only.
+
+    Parameters
+    ----------
+    field : Float[Array, "Ny Nx"]
+        T-point field.
+    grid : ArakawaCGrid2D
+        Cartesian or spherical 2-D grid.
+    mask : Mask2D or None, optional
+        Optional land/ocean mask.  Dry cells contribute zero.
+
+    Returns
+    -------
+    Float[Array, ""]
+        Scalar area-weighted sum.
+    """
+    w = area_weights(grid)
+    m = _mask_factor_2d(mask, grid)
+    return jnp.sum(_interior_2d(w * m * field))
+
+
+def area_mean(
+    field: Float[Array, "Ny Nx"],
+    grid: ArakawaCGrid2D,
+    mask: Mask2D | None = None,
+) -> Float[Array, ""]:
+    """Area-weighted mean over physical interior T-cells.
+
+    Returns ``(Σ A·m·field) / (Σ A·m)``.  Dry cells are excluded from
+    both sums.  When the total wet area is zero, returns NaN rather
+    than ±inf.
+
+    Parameters
+    ----------
+    field : Float[Array, "Ny Nx"]
+        T-point field.
+    grid : ArakawaCGrid2D
+    mask : Mask2D or None, optional
+
+    Returns
+    -------
+    Float[Array, ""]
+        Scalar area-weighted mean, or NaN if the total wet area is 0.
+    """
+    w = area_weights(grid)
+    m = _mask_factor_2d(mask, grid)
+    wm = _interior_2d(w * m)
+    num = jnp.sum(wm * _interior_2d(field))
+    den = jnp.sum(wm)
+    return jnp.where(den == 0.0, jnp.nan, num / jnp.where(den == 0.0, 1.0, den))
+
+
+# ----------------------------------------------------------------------
+# 3-D interior reductions
+# ----------------------------------------------------------------------
+
+
+def _interior_3d(
+    field: Float[Array, "Nz Ny Nx"],
+) -> Float[Array, "Nz_i Ny_i Nx_i"]:
+    return field[1:-1, 1:-1, 1:-1]
+
+
+def _mask_factor_3d(
+    mask: Mask3D | None,
+    grid: ArakawaCGrid3D,
+) -> Float[Array, "Nz Ny Nx"]:
+    if mask is None:
+        return jnp.ones((grid.Nz, grid.Ny, grid.Nx))
+    return jnp.asarray(mask.h, dtype=jnp.float64)
+
+
+def volume_sum(
+    field: Float[Array, "Nz Ny Nx"],
+    grid: ArakawaCGrid3D,
+    mask: Mask3D | None = None,
+) -> Float[Array, ""]:
+    """Volume-weighted sum over physical interior T-cells (3-D).
+
+    Same semantics as :func:`area_sum` but with the per-cell volume
+    metric ``V[k, j, i] = A[j, i] · dz`` and interior
+    ``[1:-1, 1:-1, 1:-1]``.
+
+    Parameters
+    ----------
+    field : Float[Array, "Nz Ny Nx"]
+        T-point field.
+    grid : ArakawaCGrid3D
+    mask : Mask3D or None, optional
+
+    Returns
+    -------
+    Float[Array, ""]
+    """
+    w = volume_weights(grid)
+    m = _mask_factor_3d(mask, grid)
+    return jnp.sum(_interior_3d(w * m * field))
+
+
+def volume_mean(
+    field: Float[Array, "Nz Ny Nx"],
+    grid: ArakawaCGrid3D,
+    mask: Mask3D | None = None,
+) -> Float[Array, ""]:
+    """Volume-weighted mean over physical interior T-cells (3-D).
+
+    Returns ``(Σ V·m·field) / (Σ V·m)``.  NaN when the total wet
+    volume is zero.
+    """
+    w = volume_weights(grid)
+    m = _mask_factor_3d(mask, grid)
+    wm = _interior_3d(w * m)
+    num = jnp.sum(wm * _interior_3d(field))
+    den = jnp.sum(wm)
+    return jnp.where(den == 0.0, jnp.nan, num / jnp.where(den == 0.0, 1.0, den))
+
+
+# ----------------------------------------------------------------------
+# Explicit per-coordinate convenience aliases
+# ----------------------------------------------------------------------
+
+
+def cartesian_area_sum(
+    field: Float[Array, "Ny Nx"],
+    grid: CartesianGrid2D,
+    mask: Mask2D | None = None,
+) -> Float[Array, ""]:
+    """Cartesian area-weighted sum (:func:`area_sum` with Cartesian grid)."""
+    return area_sum(field, grid, mask)
+
+
+def cartesian_area_mean(
+    field: Float[Array, "Ny Nx"],
+    grid: CartesianGrid2D,
+    mask: Mask2D | None = None,
+) -> Float[Array, ""]:
+    """Cartesian area-weighted mean."""
+    return area_mean(field, grid, mask)
+
+
+def spherical_area_sum(
+    field: Float[Array, "Ny Nx"],
+    grid: SphericalGrid2D,
+    mask: Mask2D | None = None,
+) -> Float[Array, ""]:
+    """Spherical area-weighted sum."""
+    return area_sum(field, grid, mask)
+
+
+def spherical_area_mean(
+    field: Float[Array, "Ny Nx"],
+    grid: SphericalGrid2D,
+    mask: Mask2D | None = None,
+) -> Float[Array, ""]:
+    """Spherical area-weighted mean."""
+    return area_mean(field, grid, mask)
+
+
+def cartesian_volume_sum(
+    field: Float[Array, "Nz Ny Nx"],
+    grid: CartesianGrid3D,
+    mask: Mask3D | None = None,
+) -> Float[Array, ""]:
+    """Cartesian volume-weighted sum."""
+    return volume_sum(field, grid, mask)
+
+
+def cartesian_volume_mean(
+    field: Float[Array, "Nz Ny Nx"],
+    grid: CartesianGrid3D,
+    mask: Mask3D | None = None,
+) -> Float[Array, ""]:
+    """Cartesian volume-weighted mean."""
+    return volume_mean(field, grid, mask)
+
+
+def spherical_volume_sum(
+    field: Float[Array, "Nz Ny Nx"],
+    grid: SphericalGrid3D,
+    mask: Mask3D | None = None,
+) -> Float[Array, ""]:
+    """Spherical volume-weighted sum."""
+    return volume_sum(field, grid, mask)
+
+
+def spherical_volume_mean(
+    field: Float[Array, "Nz Ny Nx"],
+    grid: SphericalGrid3D,
+    mask: Mask3D | None = None,
+) -> Float[Array, ""]:
+    """Spherical volume-weighted mean."""
+    return volume_mean(field, grid, mask)

--- a/finitevolx/_src/operators/reductions.py
+++ b/finitevolx/_src/operators/reductions.py
@@ -18,6 +18,7 @@ runtime based on the grid type, so user code can stay grid-agnostic.
 
 Example
 -------
+>>> import jax.numpy as jnp
 >>> from finitevolx import area_sum, SphericalGrid2D
 >>> grid = SphericalGrid2D.from_interior(64, 32, (0.0, 360.0), (-80.0, 80.0))
 >>> h = jnp.ones((grid.Ny, grid.Nx))
@@ -149,14 +150,28 @@ def _interior_2d(field: Float[Array, "Ny Nx"]) -> Float[Array, "Ny_i Nx_i"]:
     return field[1:-1, 1:-1]
 
 
-def _mask_factor_2d(
+def _apply_mask_2d(
+    field: Float[Array, "Ny Nx"],
+    weights: Float[Array, "Ny Nx"],
     mask: Mask2D | None,
-    grid: ArakawaCGrid2D,
-) -> Float[Array, "Ny Nx"]:
-    """Return a float mask for T-points (1.0 wet, 0.0 dry) or all-ones."""
+) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
+    """Zero out dry cells in ``field`` and ``weights`` (2-D).
+
+    Uses ``jnp.where(mask.h, x, 0.0)`` rather than a multiplicative
+    float-cast mask, so that NaN/Inf values on dry T-cells — common
+    for land cells in realistic data — cannot contaminate the wet-cell
+    totals.  Returns the inputs unchanged when ``mask is None``.  The
+    dtype of ``field`` and ``weights`` is preserved.
+    """
     if mask is None:
-        return jnp.ones((grid.Ny, grid.Nx))
-    return jnp.asarray(mask.h, dtype=jnp.float64)
+        return field, weights
+    m = mask.h  # Bool[Array, "Ny Nx"]
+    # Use plain 0.0 (weak-typed) so the mask path does not introduce an
+    # upcast to float64 on top of the input dtype; the actual dtype
+    # comes from the field/weights arrays themselves.
+    safe_field = jnp.where(m, field, 0.0)
+    safe_weights = jnp.where(m, weights, 0.0)
+    return safe_field, safe_weights
 
 
 def area_sum(
@@ -166,11 +181,11 @@ def area_sum(
 ) -> Float[Array, ""]:
     """Area-weighted sum over physical interior T-cells.
 
-    Computes ``Σ_j Σ_i A[j, i] · m[j, i] · field[j, i]`` where ``A``
-    is the per-cell area metric for the grid type (Cartesian or
-    spherical), ``m`` is the T-point wet/dry mask (1.0 wet, 0.0 dry)
-    when ``mask`` is supplied, and the sum is taken over the interior
-    ``[1:-1, 1:-1]`` only.
+    Computes ``Σ_j Σ_i A[j, i] · field[j, i]`` summed over the
+    interior ``[1:-1, 1:-1]`` only.  When ``mask`` is supplied, dry
+    T-cells are zeroed out *before* multiplication using
+    ``jnp.where(mask.h, field, 0.0)`` so NaN/Inf sentinels stored on
+    land cells cannot contaminate the result.
 
     Parameters
     ----------
@@ -184,11 +199,12 @@ def area_sum(
     Returns
     -------
     Float[Array, ""]
-        Scalar area-weighted sum.
+        Scalar area-weighted sum.  Dtype follows the promoted dtype of
+        ``field`` and the area weights.
     """
     w = area_weights(grid)
-    m = _mask_factor_2d(mask, grid)
-    return jnp.sum(_interior_2d(w * m * field))
+    f, w = _apply_mask_2d(field, w, mask)
+    return jnp.sum(_interior_2d(w * f))
 
 
 def area_mean(
@@ -198,9 +214,11 @@ def area_mean(
 ) -> Float[Array, ""]:
     """Area-weighted mean over physical interior T-cells.
 
-    Returns ``(Σ A·m·field) / (Σ A·m)``.  Dry cells are excluded from
-    both sums.  When the total wet area is zero, returns NaN rather
-    than ±inf.
+    Returns ``(Σ A·field) / (Σ A)`` over wet T-cells.  Dry cells are
+    excluded from both numerator and denominator via
+    ``jnp.where(mask.h, ..., 0.0)``, so NaN/Inf on land does not
+    contaminate the mean.  When the total wet area is zero, returns
+    NaN rather than ±inf.
 
     Parameters
     ----------
@@ -215,10 +233,10 @@ def area_mean(
         Scalar area-weighted mean, or NaN if the total wet area is 0.
     """
     w = area_weights(grid)
-    m = _mask_factor_2d(mask, grid)
-    wm = _interior_2d(w * m)
-    num = jnp.sum(wm * _interior_2d(field))
-    den = jnp.sum(wm)
+    f, w = _apply_mask_2d(field, w, mask)
+    wi = _interior_2d(w)
+    num = jnp.sum(wi * _interior_2d(f))
+    den = jnp.sum(wi)
     return jnp.where(den == 0.0, jnp.nan, num / jnp.where(den == 0.0, 1.0, den))
 
 
@@ -233,13 +251,22 @@ def _interior_3d(
     return field[1:-1, 1:-1, 1:-1]
 
 
-def _mask_factor_3d(
+def _apply_mask_3d(
+    field: Float[Array, "Nz Ny Nx"],
+    weights: Float[Array, "Nz Ny Nx"],
     mask: Mask3D | None,
-    grid: ArakawaCGrid3D,
-) -> Float[Array, "Nz Ny Nx"]:
+) -> tuple[Float[Array, "Nz Ny Nx"], Float[Array, "Nz Ny Nx"]]:
+    """Zero out dry cells in ``field`` and ``weights`` (3-D).
+
+    Same NaN/Inf-safe pattern as :func:`_apply_mask_2d`.
+    """
     if mask is None:
-        return jnp.ones((grid.Nz, grid.Ny, grid.Nx))
-    return jnp.asarray(mask.h, dtype=jnp.float64)
+        return field, weights
+    m = mask.h  # Bool[Array, "Nz Ny Nx"]
+    # See _apply_mask_2d for the weak-typed 0.0 rationale.
+    safe_field = jnp.where(m, field, 0.0)
+    safe_weights = jnp.where(m, weights, 0.0)
+    return safe_field, safe_weights
 
 
 def volume_sum(
@@ -251,7 +278,9 @@ def volume_sum(
 
     Same semantics as :func:`area_sum` but with the per-cell volume
     metric ``V[k, j, i] = A[j, i] · dz`` and interior
-    ``[1:-1, 1:-1, 1:-1]``.
+    ``[1:-1, 1:-1, 1:-1]``.  NaN/Inf-safe under masking — dry cells
+    are zeroed via ``jnp.where(mask.h, field, 0.0)`` before
+    multiplication.
 
     Parameters
     ----------
@@ -265,8 +294,8 @@ def volume_sum(
     Float[Array, ""]
     """
     w = volume_weights(grid)
-    m = _mask_factor_3d(mask, grid)
-    return jnp.sum(_interior_3d(w * m * field))
+    f, w = _apply_mask_3d(field, w, mask)
+    return jnp.sum(_interior_3d(w * f))
 
 
 def volume_mean(
@@ -276,14 +305,14 @@ def volume_mean(
 ) -> Float[Array, ""]:
     """Volume-weighted mean over physical interior T-cells (3-D).
 
-    Returns ``(Σ V·m·field) / (Σ V·m)``.  NaN when the total wet
-    volume is zero.
+    Returns ``(Σ V·field) / (Σ V)`` over wet T-cells.  NaN/Inf-safe
+    under masking; NaN when the total wet volume is zero.
     """
     w = volume_weights(grid)
-    m = _mask_factor_3d(mask, grid)
-    wm = _interior_3d(w * m)
-    num = jnp.sum(wm * _interior_3d(field))
-    den = jnp.sum(wm)
+    f, w = _apply_mask_3d(field, w, mask)
+    wi = _interior_3d(w)
+    num = jnp.sum(wi * _interior_3d(f))
+    den = jnp.sum(wi)
     return jnp.where(den == 0.0, jnp.nan, num / jnp.where(den == 0.0, 1.0, den))
 
 

--- a/tests/test_reductions.py
+++ b/tests/test_reductions.py
@@ -384,3 +384,170 @@ class TestVolume:
             np.zeros((cart_grid.Nz, cart_grid.Ny, cart_grid.Nx), dtype=bool)
         )
         assert jnp.isnan(volume_mean(h, cart_grid, mask=all_dry))
+
+
+# ======================================================================
+# NaN/Inf on dry cells — must not contaminate wet totals
+# (PR #221 feedback: IEEE 0 * NaN = NaN.)
+# ======================================================================
+
+
+class TestDryCellNaNSafety:
+    def test_area_sum_dry_nan_does_not_contaminate(self):
+        grid = CartesianGrid2D.from_interior(
+            nx_interior=10, ny_interior=8, Lx=10.0, Ly=8.0
+        )
+        mask_arr = np.ones((grid.Ny, grid.Nx), dtype=bool)
+        mask_arr[3, 4] = False
+        m = Mask2D.from_mask(mask_arr)
+
+        field_np = np.ones((grid.Ny, grid.Nx))
+        field_np[3, 4] = np.nan  # common sentinel on land
+        field = jnp.asarray(field_np)
+
+        s = area_sum(field, grid, mask=m)
+        assert jnp.isfinite(s)
+        # Expected sum: (Nx-2)(Ny-2) - 1 wet cells, each unit value times cell area.
+        expected = ((grid.Nx - 2) * (grid.Ny - 2) - 1) * grid.dx * grid.dy
+        np.testing.assert_allclose(float(s), expected, rtol=1e-12)
+
+    def test_area_mean_dry_nan_does_not_contaminate(self):
+        grid = SphericalGrid2D.from_interior(
+            16,
+            10,
+            lon_range=(0.0, 360.0),
+            lat_range=(-40.0, 40.0),
+            R=R,
+        )
+        mask_arr = np.ones((grid.Ny, grid.Nx), dtype=bool)
+        mask_arr[2, 6] = False
+        m = Mask2D.from_mask(mask_arr)
+
+        field_np = 2.5 * np.ones((grid.Ny, grid.Nx))
+        field_np[2, 6] = np.inf  # land sentinel (could be NaN or Inf)
+        field = jnp.asarray(field_np)
+
+        mean = area_mean(field, grid, mask=m)
+        assert jnp.isfinite(mean)
+        np.testing.assert_allclose(float(mean), 2.5, rtol=1e-10)
+
+    def test_volume_sum_dry_nan_does_not_contaminate(self):
+        grid = CartesianGrid3D.from_interior(
+            nx_interior=6,
+            ny_interior=6,
+            nz_interior=4,
+            Lx=1.0,
+            Ly=1.0,
+            Lz=1.0,
+        )
+        mask_arr = np.ones((grid.Nz, grid.Ny, grid.Nx), dtype=bool)
+        mask_arr[1, 2, 3] = False
+        m = Mask3D.from_mask(mask_arr)
+
+        field_np = np.ones((grid.Nz, grid.Ny, grid.Nx))
+        field_np[1, 2, 3] = np.nan
+        field = jnp.asarray(field_np)
+
+        s = volume_sum(field, grid, mask=m)
+        assert jnp.isfinite(s)
+        cell_vol = grid.dx * grid.dy * grid.dz
+        interior_cells = (grid.Nz - 2) * (grid.Ny - 2) * (grid.Nx - 2)
+        expected = (interior_cells - 1) * cell_vol
+        np.testing.assert_allclose(float(s), expected, rtol=1e-12)
+
+    def test_volume_mean_dry_nan_does_not_contaminate(self):
+        grid = SphericalGrid3D.from_interior(
+            16,
+            10,
+            nz_interior=3,
+            lon_range=(0.0, 360.0),
+            lat_range=(-40.0, 40.0),
+            Lz=100.0,
+            R=R,
+        )
+        mask_arr = np.ones((grid.Nz, grid.Ny, grid.Nx), dtype=bool)
+        mask_arr[1, 3, 5] = False
+        m = Mask3D.from_mask(mask_arr)
+
+        field_np = 7.0 * np.ones((grid.Nz, grid.Ny, grid.Nx))
+        field_np[1, 3, 5] = np.nan
+        field = jnp.asarray(field_np)
+
+        mean = volume_mean(field, grid, mask=m)
+        assert jnp.isfinite(mean)
+        np.testing.assert_allclose(float(mean), 7.0, rtol=1e-10)
+
+
+# ======================================================================
+# Dtype preservation (PR #221 feedback: no silent float32 → float64)
+# ======================================================================
+
+
+class TestDtypePreservation:
+    """The mask path must not silently upcast beyond the unmasked path.
+
+    The OLD code forced ``mask.h`` to ``float64`` via
+    ``jnp.asarray(mask.h, dtype=jnp.float64)``, so enabling a mask
+    would silently upgrade a float32 workload to float64.  The fix
+    uses ``jnp.where(mask.h, …, 0.0)``, leaving dtype selection
+    entirely to JAX's normal promotion rules (driven by ``field`` and
+    the grid-derived weights).  These tests pin that "masked == unmasked
+    dtype" invariant across both sum and mean, 2-D and 3-D, Cartesian
+    and spherical.  The exact resulting dtype depends on JAX's weak-
+    type promotion (e.g. ``jnp.sum(weak_f64 * strong_f32)`` stays
+    float32) and is not the concern here — the concern is that the
+    mask does not introduce an *additional* upcast.
+    """
+
+    def test_area_sum_mask_matches_unmasked_dtype_cartesian(self):
+        grid = CartesianGrid2D.from_interior(
+            nx_interior=8,
+            ny_interior=6,
+            Lx=1.0,
+            Ly=1.0,
+        )
+        field = jnp.ones((grid.Ny, grid.Nx), dtype=jnp.float32)
+        m = Mask2D.from_mask(np.ones((grid.Ny, grid.Nx), dtype=bool))
+        assert area_sum(field, grid, mask=m).dtype == area_sum(field, grid).dtype
+        assert area_mean(field, grid, mask=m).dtype == area_mean(field, grid).dtype
+
+    def test_area_sum_mask_matches_unmasked_dtype_spherical(self):
+        grid = SphericalGrid2D.from_interior(
+            16,
+            10,
+            lon_range=(0.0, 360.0),
+            lat_range=(-40.0, 40.0),
+            R=R,
+        )
+        field = jnp.ones((grid.Ny, grid.Nx), dtype=jnp.float32)
+        m = Mask2D.from_mask(np.ones((grid.Ny, grid.Nx), dtype=bool))
+        assert area_sum(field, grid, mask=m).dtype == area_sum(field, grid).dtype
+        assert area_mean(field, grid, mask=m).dtype == area_mean(field, grid).dtype
+
+    def test_volume_mask_matches_unmasked_dtype(self):
+        grid = CartesianGrid3D.from_interior(
+            nx_interior=4,
+            ny_interior=4,
+            nz_interior=3,
+            Lx=1.0,
+            Ly=1.0,
+            Lz=1.0,
+        )
+        field = jnp.ones((grid.Nz, grid.Ny, grid.Nx), dtype=jnp.float32)
+        m = Mask3D.from_mask(np.ones((grid.Nz, grid.Ny, grid.Nx), dtype=bool))
+        assert volume_sum(field, grid, mask=m).dtype == volume_sum(field, grid).dtype
+        assert volume_mean(field, grid, mask=m).dtype == volume_mean(field, grid).dtype
+
+    def test_float32_sum_stays_float32(self):
+        """Under JAX weak promotion, f32 field × weak-f64 weights → f32."""
+        grid = CartesianGrid2D.from_interior(
+            nx_interior=8,
+            ny_interior=6,
+            Lx=1.0,
+            Ly=1.0,
+        )
+        field = jnp.ones((grid.Ny, grid.Nx), dtype=jnp.float32)
+        m = Mask2D.from_mask(np.ones((grid.Ny, grid.Nx), dtype=bool))
+        # This is the concrete regression guard from the reviewer
+        # comment: the OLD code returned float64 here.
+        assert area_sum(field, grid, mask=m).dtype == jnp.float32

--- a/tests/test_reductions.py
+++ b/tests/test_reductions.py
@@ -1,0 +1,386 @@
+"""Tests for area/volume-weighted reduction helpers (Cartesian + spherical)."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from finitevolx._src.grid.cartesian import CartesianGrid2D, CartesianGrid3D
+from finitevolx._src.grid.spherical import SphericalGrid2D, SphericalGrid3D
+from finitevolx._src.mask import Mask2D, Mask3D
+from finitevolx._src.operators.reductions import (
+    area_mean,
+    area_sum,
+    area_weights,
+    cartesian_area_mean,
+    cartesian_area_sum,
+    cartesian_volume_mean,
+    cartesian_volume_sum,
+    spherical_area_mean,
+    spherical_area_sum,
+    spherical_area_weights,
+    spherical_volume_mean,
+    spherical_volume_sum,
+    volume_mean,
+    volume_sum,
+    volume_weights,
+)
+
+jax.config.update("jax_enable_x64", True)
+
+
+R = 6.371e6
+
+
+# ======================================================================
+# Weights
+# ======================================================================
+
+
+class TestWeights:
+    def test_cartesian_area_weights_uniform(self):
+        grid = CartesianGrid2D.from_interior(
+            nx_interior=10, ny_interior=8, Lx=20.0, Ly=16.0
+        )
+        w = area_weights(grid)
+        np.testing.assert_allclose(w, grid.dx * grid.dy)
+
+    def test_spherical_area_weights_cos_weighted(self):
+        grid = SphericalGrid2D.from_interior(
+            nx_interior=10,
+            ny_interior=8,
+            lon_range=(0.0, 360.0),
+            lat_range=(-80.0, 80.0),
+            R=R,
+        )
+        w = area_weights(grid)
+        expected = grid.R**2 * grid.dlon * grid.dlat * grid.cos_lat_T
+        np.testing.assert_allclose(w, expected, rtol=1e-12)
+
+    def test_volume_weights_cartesian(self):
+        grid = CartesianGrid3D.from_interior(
+            nx_interior=8,
+            ny_interior=8,
+            nz_interior=4,
+            Lx=1.0,
+            Ly=1.0,
+            Lz=1.0,
+        )
+        w = volume_weights(grid)
+        np.testing.assert_allclose(w, grid.dx * grid.dy * grid.dz)
+
+    def test_volume_weights_spherical(self):
+        grid = SphericalGrid3D.from_interior(
+            nx_interior=8,
+            ny_interior=6,
+            nz_interior=3,
+            lon_range=(0.0, 360.0),
+            lat_range=(-40.0, 40.0),
+            Lz=100.0,
+            R=R,
+        )
+        w = volume_weights(grid)
+        expected_2d = spherical_area_weights(grid.horizontal_grid()) * grid.dz
+        for k in range(grid.Nz):
+            np.testing.assert_allclose(w[k], expected_2d, rtol=1e-12)
+
+    def test_unsupported_grid_raises(self):
+        class FakeGrid:
+            Ny = 1
+            Nx = 1
+
+        with pytest.raises(TypeError, match="unsupported grid type"):
+            area_weights(FakeGrid())
+
+
+# ======================================================================
+# Area sum / mean — Cartesian
+# ======================================================================
+
+
+class TestCartesianArea:
+    @pytest.fixture
+    def grid(self):
+        return CartesianGrid2D.from_interior(
+            nx_interior=10, ny_interior=8, Lx=10.0, Ly=8.0
+        )
+
+    def test_constant_field_area_sum(self, grid):
+        h = 3.0 * jnp.ones((grid.Ny, grid.Nx))
+        # Total wet area = interior_cells · dx · dy
+        interior_cells = (grid.Ny - 2) * (grid.Nx - 2)
+        expected = 3.0 * interior_cells * grid.dx * grid.dy
+        np.testing.assert_allclose(area_sum(h, grid), expected, rtol=1e-12)
+
+    def test_area_mean_constant_is_field_value(self, grid):
+        c = 7.2
+        h = c * jnp.ones((grid.Ny, grid.Nx))
+        np.testing.assert_allclose(area_mean(h, grid), c, rtol=1e-12)
+
+    def test_ghost_ring_ignored(self, grid):
+        h = jnp.zeros((grid.Ny, grid.Nx))
+        # Pollute ghost ring — it should be ignored.
+        h = h.at[0, :].set(1e6).at[-1, :].set(1e6).at[:, 0].set(1e6).at[:, -1].set(1e6)
+        np.testing.assert_allclose(area_sum(h, grid), 0.0, atol=1e-10)
+
+    def test_alias_cartesian_area_sum(self, grid):
+        h = jnp.arange(grid.Ny * grid.Nx, dtype=float).reshape(grid.Ny, grid.Nx)
+        np.testing.assert_allclose(
+            cartesian_area_sum(h, grid),
+            area_sum(h, grid),
+            rtol=1e-12,
+        )
+        np.testing.assert_allclose(
+            cartesian_area_mean(h, grid),
+            area_mean(h, grid),
+            rtol=1e-12,
+        )
+
+    def test_all_dry_mean_is_nan(self, grid):
+        h = jnp.ones((grid.Ny, grid.Nx))
+        all_dry = Mask2D.from_mask(np.zeros((grid.Ny, grid.Nx), dtype=bool))
+        assert jnp.isnan(area_mean(h, grid, mask=all_dry))
+
+    def test_mask_excludes_dry_cells(self, grid):
+        h = jnp.ones((grid.Ny, grid.Nx))
+        m = np.ones((grid.Ny, grid.Nx), dtype=bool)
+        m[3, 4] = False
+        area_mask = Mask2D.from_mask(m)
+        s = area_sum(h, grid, mask=area_mask)
+        # Total wet interior area is (Nx-2)(Ny-2) - 1 cells.
+        expected = ((grid.Nx - 2) * (grid.Ny - 2) - 1) * grid.dx * grid.dy
+        np.testing.assert_allclose(s, expected, rtol=1e-12)
+
+
+# ======================================================================
+# Area sum / mean — Spherical
+# ======================================================================
+
+
+class TestSphericalArea:
+    def test_full_sphere_area_sum_approaches_4piR2(self):
+        """Integrating 1 over the full sphere approximates 4πR²."""
+        grid = SphericalGrid2D.from_interior(
+            nx_interior=128,
+            ny_interior=64,
+            lon_range=(0.0, 360.0),
+            lat_range=(-90.0, 90.0),
+            R=R,
+        )
+        h = jnp.ones((grid.Ny, grid.Nx))
+        total = area_sum(h, grid)
+        expected = 4.0 * jnp.pi * R**2
+        # Discretization introduces a ~1% error at this resolution; the
+        # key property we care about is the right order of magnitude and
+        # that refining the grid reduces the error.
+        np.testing.assert_allclose(float(total), float(expected), rtol=0.02)
+
+    def test_refining_grid_reduces_error(self):
+        coarse = SphericalGrid2D.from_interior(
+            32,
+            16,
+            lon_range=(0.0, 360.0),
+            lat_range=(-80.0, 80.0),
+            R=R,
+        )
+        fine = SphericalGrid2D.from_interior(
+            128,
+            64,
+            lon_range=(0.0, 360.0),
+            lat_range=(-80.0, 80.0),
+            R=R,
+        )
+        h_c = jnp.ones((coarse.Ny, coarse.Nx))
+        h_f = jnp.ones((fine.Ny, fine.Nx))
+
+        # Analytical area of the lat band (-80, 80) on a sphere of radius R:
+        #   A = 2π R² [sin(lat_max) - sin(lat_min)]
+        lat_min_rad = jnp.deg2rad(-80.0)
+        lat_max_rad = jnp.deg2rad(80.0)
+        expected = 2.0 * jnp.pi * R**2 * (jnp.sin(lat_max_rad) - jnp.sin(lat_min_rad))
+
+        err_c = abs(float(area_sum(h_c, coarse)) - float(expected)) / float(expected)
+        err_f = abs(float(area_sum(h_f, fine)) - float(expected)) / float(expected)
+        assert err_f < err_c
+
+    def test_constant_mean_is_field_value(self):
+        grid = SphericalGrid2D.from_interior(
+            32,
+            16,
+            lon_range=(0.0, 360.0),
+            lat_range=(-80.0, 80.0),
+            R=R,
+        )
+        c = 5.0
+        h = c * jnp.ones((grid.Ny, grid.Nx))
+        np.testing.assert_allclose(area_mean(h, grid), c, rtol=1e-10)
+
+    def test_equatorial_limit_matches_cartesian(self):
+        """Narrow lat band around equator → spherical ≈ cartesian sum."""
+        nx, ny = 32, 4
+        sphere = SphericalGrid2D.from_interior(
+            nx,
+            ny,
+            lon_range=(0.0, 10.0),
+            lat_range=(-0.1, 0.1),
+            R=R,
+        )
+        cart = CartesianGrid2D.from_interior(
+            nx,
+            ny,
+            Lx=sphere.Lx,
+            Ly=sphere.Ly,
+        )
+        key = jax.random.PRNGKey(7)
+        h = jax.random.normal(key, (sphere.Ny, sphere.Nx))
+        s_sph = area_sum(h, sphere)
+        s_cart = area_sum(h, cart)
+        np.testing.assert_allclose(float(s_sph), float(s_cart), rtol=1e-4)
+
+    def test_alias_spherical_area_sum(self):
+        grid = SphericalGrid2D.from_interior(
+            16,
+            10,
+            lon_range=(0.0, 360.0),
+            lat_range=(-40.0, 40.0),
+            R=R,
+        )
+        key = jax.random.PRNGKey(8)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        np.testing.assert_allclose(
+            spherical_area_sum(h, grid),
+            area_sum(h, grid),
+            rtol=1e-12,
+        )
+        np.testing.assert_allclose(
+            spherical_area_mean(h, grid),
+            area_mean(h, grid),
+            rtol=1e-12,
+        )
+
+    def test_masked_all_dry_mean_nan(self):
+        grid = SphericalGrid2D.from_interior(
+            16,
+            10,
+            lon_range=(0.0, 360.0),
+            lat_range=(-40.0, 40.0),
+            R=R,
+        )
+        h = jnp.ones((grid.Ny, grid.Nx))
+        all_dry = Mask2D.from_mask(np.zeros((grid.Ny, grid.Nx), dtype=bool))
+        assert jnp.isnan(area_mean(h, grid, mask=all_dry))
+
+    def test_jit_grad(self):
+        grid = SphericalGrid2D.from_interior(
+            16,
+            10,
+            lon_range=(0.0, 360.0),
+            lat_range=(-40.0, 40.0),
+            R=R,
+        )
+        h = jnp.ones((grid.Ny, grid.Nx))
+        np.testing.assert_allclose(
+            jax.jit(lambda x: area_sum(x, grid))(h),
+            area_sum(h, grid),
+        )
+        g = jax.grad(lambda x: area_sum(x, grid))(h)
+        assert g.shape == h.shape
+        assert jnp.all(jnp.isfinite(g))
+
+
+# ======================================================================
+# Volume sum / mean
+# ======================================================================
+
+
+class TestVolume:
+    @pytest.fixture
+    def cart_grid(self):
+        return CartesianGrid3D.from_interior(
+            nx_interior=8,
+            ny_interior=6,
+            nz_interior=4,
+            Lx=1.0,
+            Ly=1.0,
+            Lz=1.0,
+        )
+
+    @pytest.fixture
+    def sph_grid(self):
+        return SphericalGrid3D.from_interior(
+            nx_interior=16,
+            ny_interior=10,
+            nz_interior=4,
+            lon_range=(0.0, 360.0),
+            lat_range=(-40.0, 40.0),
+            Lz=100.0,
+            R=R,
+        )
+
+    def test_cartesian_constant_volume_sum(self, cart_grid):
+        h = 2.0 * jnp.ones((cart_grid.Nz, cart_grid.Ny, cart_grid.Nx))
+        interior = (cart_grid.Nz - 2) * (cart_grid.Ny - 2) * (cart_grid.Nx - 2)
+        expected = 2.0 * interior * cart_grid.dx * cart_grid.dy * cart_grid.dz
+        np.testing.assert_allclose(volume_sum(h, cart_grid), expected, rtol=1e-12)
+
+    def test_cartesian_volume_mean_constant(self, cart_grid):
+        c = -1.5
+        h = c * jnp.ones((cart_grid.Nz, cart_grid.Ny, cart_grid.Nx))
+        np.testing.assert_allclose(volume_mean(h, cart_grid), c, rtol=1e-12)
+
+    def test_spherical_volume_mean_constant(self, sph_grid):
+        c = 3.14
+        h = c * jnp.ones((sph_grid.Nz, sph_grid.Ny, sph_grid.Nx))
+        np.testing.assert_allclose(volume_mean(h, sph_grid), c, rtol=1e-10)
+
+    def test_spherical_volume_equals_area_times_dz_nz(self, sph_grid):
+        h = jnp.ones((sph_grid.Nz, sph_grid.Ny, sph_grid.Nx))
+        v = volume_sum(h, sph_grid)
+        area = area_sum(
+            jnp.ones((sph_grid.Ny, sph_grid.Nx)), sph_grid.horizontal_grid()
+        )
+        expected = area * sph_grid.dz * (sph_grid.Nz - 2)
+        np.testing.assert_allclose(float(v), float(expected), rtol=1e-12)
+
+    def test_aliases(self, cart_grid, sph_grid):
+        h_c = jnp.ones((cart_grid.Nz, cart_grid.Ny, cart_grid.Nx))
+        h_s = jnp.ones((sph_grid.Nz, sph_grid.Ny, sph_grid.Nx))
+        np.testing.assert_allclose(
+            cartesian_volume_sum(h_c, cart_grid),
+            volume_sum(h_c, cart_grid),
+        )
+        np.testing.assert_allclose(
+            cartesian_volume_mean(h_c, cart_grid),
+            volume_mean(h_c, cart_grid),
+        )
+        np.testing.assert_allclose(
+            spherical_volume_sum(h_s, sph_grid),
+            volume_sum(h_s, sph_grid),
+        )
+        np.testing.assert_allclose(
+            spherical_volume_mean(h_s, sph_grid),
+            volume_mean(h_s, sph_grid),
+        )
+
+    def test_mask_excludes_dry_volume(self, cart_grid):
+        h = jnp.ones((cart_grid.Nz, cart_grid.Ny, cart_grid.Nx))
+        m = np.ones((cart_grid.Nz, cart_grid.Ny, cart_grid.Nx), dtype=bool)
+        m[1, 2, 3] = False
+        vmask = Mask3D.from_mask(m)
+        cell_vol = cart_grid.dx * cart_grid.dy * cart_grid.dz
+        total_interior = (cart_grid.Nz - 2) * (cart_grid.Ny - 2) * (cart_grid.Nx - 2)
+        expected = (total_interior - 1) * cell_vol
+        np.testing.assert_allclose(
+            volume_sum(h, cart_grid, mask=vmask),
+            expected,
+            rtol=1e-12,
+        )
+
+    def test_all_dry_volume_mean_nan(self, cart_grid):
+        h = jnp.ones((cart_grid.Nz, cart_grid.Ny, cart_grid.Nx))
+        all_dry = Mask3D.from_mask(
+            np.zeros((cart_grid.Nz, cart_grid.Ny, cart_grid.Nx), dtype=bool)
+        )
+        assert jnp.isnan(volume_mean(h, cart_grid, mask=all_dry))

--- a/tests/test_spherical_diffusion.py
+++ b/tests/test_spherical_diffusion.py
@@ -1,4 +1,4 @@
-"""Tests for SphericalDiffusion2D and SphericalDiffusion3D."""
+"""Tests for spherical diffusion (harmonic + biharmonic)."""
 
 from __future__ import annotations
 
@@ -7,8 +7,10 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from finitevolx._src.diffusion.diffusion import Diffusion2D
+from finitevolx._src.diffusion.diffusion import BiharmonicDiffusion2D, Diffusion2D
 from finitevolx._src.diffusion.spherical_diffusion import (
+    SphericalBiharmonicDiffusion2D,
+    SphericalBiharmonicDiffusion3D,
     SphericalDiffusion2D,
     SphericalDiffusion3D,
 )
@@ -280,5 +282,178 @@ class TestSphericalDiffusion3D:
         out = jitted(h, 1.0)
         assert out.shape == h.shape
         g = jax.grad(lambda x: diff_op3d(x, 1.0).sum())(h)
+        assert g.shape == h.shape
+        assert jnp.all(jnp.isfinite(g))
+
+
+# ======================================================================
+# SphericalBiharmonicDiffusion2D
+# ======================================================================
+
+
+class TestSphericalBiharmonicDiffusion2D:
+    @pytest.fixture
+    def op(self, grid):
+        return SphericalBiharmonicDiffusion2D(grid=grid)
+
+    def test_output_shape(self, op, grid):
+        h = jnp.ones((grid.Ny, grid.Nx))
+        assert op(h, kappa=1.0).shape == (grid.Ny, grid.Nx)
+
+    def test_ghost_ring_zero(self, op, grid):
+        key = jax.random.PRNGKey(40)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        out = op(h, kappa=1.0)
+        np.testing.assert_allclose(out[0, :], 0.0)
+        np.testing.assert_allclose(out[-1, :], 0.0)
+        np.testing.assert_allclose(out[:, 0], 0.0)
+        np.testing.assert_allclose(out[:, -1], 0.0)
+
+    def test_constant_field_zero(self, op, grid):
+        h = 4.2 * jnp.ones((grid.Ny, grid.Nx))
+        np.testing.assert_allclose(op(h, kappa=1.0)[1:-1, 1:-1], 0.0, atol=1e-10)
+
+    def test_kappa_scales_linearly(self, op, grid):
+        key = jax.random.PRNGKey(41)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        t1 = op(h, kappa=1.0)
+        t2 = op(h, kappa=2.5)
+        np.testing.assert_allclose(t2[1:-1, 1:-1], 2.5 * t1[1:-1, 1:-1], rtol=1e-10)
+
+    def test_zero_kappa(self, op, grid):
+        key = jax.random.PRNGKey(42)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        np.testing.assert_allclose(op(h, kappa=0.0), 0.0, atol=1e-12)
+
+    def test_sign_is_dissipative_for_small_scales(self, grid):
+        """For a short-wave mode, positive kappa should dissipate.
+
+        Evaluates -kappa * nabla^4 h on a sinusoidal field and checks
+        that the sign of the tendency opposes the field at interior
+        cells — the defining property of dissipative biharmonic mixing.
+        """
+        op = SphericalBiharmonicDiffusion2D(grid=grid)
+        # Use grid indices to get an oscillating pattern.
+        jj, ii = jnp.indices((grid.Ny, grid.Nx))
+        h = jnp.cos(jnp.pi * ii / 3.0) * jnp.cos(jnp.pi * jj / 3.0)
+        tend = op(h, kappa=1.0)
+        # In the deep interior, sign(tend) * sign(h) should be <= 0
+        # for a dissipative operator.
+        deep_h = h[3:-3, 3:-3]
+        deep_t = tend[3:-3, 3:-3]
+        # Amplitudes where |h| is large — should be clearly opposite-signed.
+        large = jnp.abs(deep_h) > 0.5
+        assert jnp.all(jnp.where(large, deep_t * deep_h <= 0, True))
+
+    def test_matches_cartesian_at_narrow_equatorial_band(self):
+        nx, ny = 20, 6
+        sphere = SphericalGrid2D.from_interior(
+            nx_interior=nx,
+            ny_interior=ny,
+            lon_range=(0.0, 20.0),
+            lat_range=(-0.5, 0.5),
+            R=R,
+        )
+        cart = CartesianGrid2D.from_interior(
+            nx_interior=nx,
+            ny_interior=ny,
+            Lx=sphere.Lx,
+            Ly=sphere.Ly,
+        )
+        key = jax.random.PRNGKey(43)
+        h = jax.random.normal(key, (sphere.Ny, sphere.Nx))
+        t_s = SphericalBiharmonicDiffusion2D(grid=sphere)(h, kappa=1.0)
+        t_c = BiharmonicDiffusion2D(grid=cart)(h, kappa=1.0)
+        np.testing.assert_allclose(
+            t_s[2:-2, 2:-2],
+            t_c[2:-2, 2:-2],
+            rtol=5e-3,
+            atol=5e-3,
+        )
+
+    def test_jit_grad(self, op, grid):
+        key = jax.random.PRNGKey(44)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        out = jax.jit(op.__call__)(h, 1.0)
+        assert out.shape == h.shape
+        g = jax.grad(lambda x: op(x, 1.0).sum())(h)
+        assert g.shape == h.shape
+        assert jnp.all(jnp.isfinite(g))
+
+    def test_masked_all_dry_zero(self, grid):
+        all_dry = Mask2D.from_mask(np.zeros((grid.Ny, grid.Nx), dtype=bool))
+        op = SphericalBiharmonicDiffusion2D(grid=grid, mask=all_dry)
+        key = jax.random.PRNGKey(45)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        np.testing.assert_allclose(op(h, kappa=1.0), 0.0, atol=1e-12)
+
+    def test_masked_all_wet_matches_unmasked(self, grid):
+        all_wet = Mask2D.from_mask(np.ones((grid.Ny, grid.Nx), dtype=bool))
+        op_m = SphericalBiharmonicDiffusion2D(grid=grid, mask=all_wet)
+        op_u = SphericalBiharmonicDiffusion2D(grid=grid)
+        key = jax.random.PRNGKey(46)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        np.testing.assert_allclose(op_m(h, 1.0), op_u(h, 1.0), atol=1e-12)
+
+    def test_dry_cell_zero(self, grid):
+        m = np.ones((grid.Ny, grid.Nx), dtype=bool)
+        m[4, 7] = False
+        op = SphericalBiharmonicDiffusion2D(grid=grid, mask=Mask2D.from_mask(m))
+        key = jax.random.PRNGKey(47)
+        h = jax.random.normal(key, (grid.Ny, grid.Nx))
+        out = op(h, kappa=1.0)
+        assert float(out[4, 7]) == 0.0
+
+
+# ======================================================================
+# SphericalBiharmonicDiffusion3D
+# ======================================================================
+
+
+class TestSphericalBiharmonicDiffusion3D:
+    @pytest.fixture
+    def op(self, grid3d):
+        return SphericalBiharmonicDiffusion3D(grid=grid3d)
+
+    def test_output_shape(self, op, grid3d):
+        h = jnp.ones((grid3d.Nz, grid3d.Ny, grid3d.Nx))
+        assert op(h, kappa=1.0).shape == (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+
+    def test_constant_zero(self, op, grid3d):
+        h = 1.7 * jnp.ones((grid3d.Nz, grid3d.Ny, grid3d.Nx))
+        np.testing.assert_allclose(op(h, kappa=1.0)[:, 1:-1, 1:-1], 0.0, atol=1e-10)
+
+    def test_z_ghost_slices_zero(self, op, grid3d):
+        key = jax.random.PRNGKey(48)
+        h = jax.random.normal(key, (grid3d.Nz, grid3d.Ny, grid3d.Nx))
+        out = op(h, kappa=1.0)
+        np.testing.assert_allclose(out[0], 0.0, atol=1e-10)
+        np.testing.assert_allclose(out[-1], 0.0, atol=1e-10)
+
+    def test_matches_2d_per_level(self, op, grid3d):
+        op2d = SphericalBiharmonicDiffusion2D(grid=grid3d.horizontal_grid())
+        key = jax.random.PRNGKey(49)
+        h2 = jax.random.normal(key, (grid3d.Ny, grid3d.Nx))
+        h3 = jnp.broadcast_to(h2, (grid3d.Nz, grid3d.Ny, grid3d.Nx))
+        t2 = op2d(h2, kappa=1.0)
+        t3 = op(h3, kappa=1.0)
+        for k in range(1, grid3d.Nz - 1):
+            np.testing.assert_allclose(t3[k], t2, atol=1e-12)
+
+    def test_masked_all_dry_zero(self, grid3d):
+        all_dry = Mask3D.from_mask(
+            np.zeros((grid3d.Nz, grid3d.Ny, grid3d.Nx), dtype=bool)
+        )
+        op = SphericalBiharmonicDiffusion3D(grid=grid3d, mask=all_dry)
+        key = jax.random.PRNGKey(50)
+        h = jax.random.normal(key, (grid3d.Nz, grid3d.Ny, grid3d.Nx))
+        np.testing.assert_allclose(op(h, kappa=1.0), 0.0, atol=1e-12)
+
+    def test_jit_grad(self, op, grid3d):
+        key = jax.random.PRNGKey(51)
+        h = jax.random.normal(key, (grid3d.Nz, grid3d.Ny, grid3d.Nx))
+        out = jax.jit(op.__call__)(h, 1.0)
+        assert out.shape == h.shape
+        g = jax.grad(lambda x: op(x, 1.0).sum())(h)
         assert g.shape == h.shape
         assert jnp.all(jnp.isfinite(g))

--- a/tests/test_spherical_momentum.py
+++ b/tests/test_spherical_momentum.py
@@ -1,0 +1,291 @@
+"""Tests for SphericalMomentumAdvection2D and SphericalMomentumAdvection3D."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from finitevolx._src.diffusion.momentum import MomentumAdvection2D
+from finitevolx._src.diffusion.spherical_momentum import (
+    SphericalMomentumAdvection2D,
+    SphericalMomentumAdvection3D,
+)
+from finitevolx._src.grid.cartesian import CartesianGrid2D
+from finitevolx._src.grid.spherical import SphericalGrid2D, SphericalGrid3D
+from finitevolx._src.mask import Mask2D, Mask3D
+
+jax.config.update("jax_enable_x64", True)
+
+
+R = 6.371e6
+NX_INT, NY_INT = 14, 10
+
+
+@pytest.fixture
+def grid():
+    return SphericalGrid2D.from_interior(
+        nx_interior=NX_INT,
+        ny_interior=NY_INT,
+        lon_range=(0.0, 360.0),
+        lat_range=(-40.0, 40.0),
+        R=R,
+    )
+
+
+@pytest.fixture
+def grid3d():
+    return SphericalGrid3D.from_interior(
+        nx_interior=NX_INT,
+        ny_interior=NY_INT,
+        nz_interior=3,
+        lon_range=(0.0, 360.0),
+        lat_range=(-40.0, 40.0),
+        Lz=100.0,
+        R=R,
+    )
+
+
+# ======================================================================
+# SphericalMomentumAdvection2D
+# ======================================================================
+
+
+class TestSphericalMomentumAdvection2D:
+    @pytest.fixture
+    def madv(self, grid):
+        return SphericalMomentumAdvection2D(grid=grid)
+
+    def test_output_shapes(self, madv, grid):
+        u = jnp.zeros((grid.Ny, grid.Nx))
+        v = jnp.zeros((grid.Ny, grid.Nx))
+        du, dv = madv(u, v)
+        assert du.shape == (grid.Ny, grid.Nx)
+        assert dv.shape == (grid.Ny, grid.Nx)
+
+    def test_zero_velocity_zero_tendency(self, madv, grid):
+        u = jnp.zeros((grid.Ny, grid.Nx))
+        v = jnp.zeros((grid.Ny, grid.Nx))
+        du, dv = madv(u, v)
+        np.testing.assert_allclose(du, 0.0, atol=1e-12)
+        np.testing.assert_allclose(dv, 0.0, atol=1e-12)
+
+    def test_outer_ghost_ring_zero(self, madv, grid):
+        key = jax.random.PRNGKey(0)
+        k1, k2 = jax.random.split(key)
+        u = jax.random.normal(k1, (grid.Ny, grid.Nx))
+        v = jax.random.normal(k2, (grid.Ny, grid.Nx))
+        du, dv = madv(u, v)
+        for field in (du, dv):
+            np.testing.assert_allclose(field[:2, :], 0.0)
+            np.testing.assert_allclose(field[-2:, :], 0.0)
+            np.testing.assert_allclose(field[:, :2], 0.0)
+            np.testing.assert_allclose(field[:, -2:], 0.0)
+
+    @pytest.mark.parametrize("scheme", ["energy", "enstrophy", "al"])
+    def test_schemes_produce_finite_output(self, madv, grid, scheme):
+        key = jax.random.PRNGKey(1)
+        k1, k2 = jax.random.split(key)
+        u = jax.random.normal(k1, (grid.Ny, grid.Nx))
+        v = jax.random.normal(k2, (grid.Ny, grid.Nx))
+        du, dv = madv(u, v, scheme=scheme)
+        assert jnp.all(jnp.isfinite(du))
+        assert jnp.all(jnp.isfinite(dv))
+
+    def test_invalid_scheme_raises(self, madv, grid):
+        u = jnp.zeros((grid.Ny, grid.Nx))
+        v = jnp.zeros((grid.Ny, grid.Nx))
+        with pytest.raises(ValueError, match="Unknown scheme"):
+            madv(u, v, scheme="bogus")
+
+    @pytest.mark.parametrize("scheme", ["energy", "enstrophy", "al"])
+    def test_matches_cartesian_at_narrow_equatorial_band(self, scheme):
+        nx, ny = 20, 6
+        sphere = SphericalGrid2D.from_interior(
+            nx_interior=nx,
+            ny_interior=ny,
+            lon_range=(0.0, 20.0),
+            lat_range=(-0.5, 0.5),
+            R=R,
+        )
+        cart = CartesianGrid2D.from_interior(
+            nx_interior=nx,
+            ny_interior=ny,
+            Lx=sphere.Lx,
+            Ly=sphere.Ly,
+        )
+        key = jax.random.PRNGKey(2)
+        k1, k2 = jax.random.split(key)
+        u = jax.random.normal(k1, (sphere.Ny, sphere.Nx))
+        v = jax.random.normal(k2, (sphere.Ny, sphere.Nx))
+
+        madv_s = SphericalMomentumAdvection2D(grid=sphere)
+        madv_c = MomentumAdvection2D(grid=cart)
+        du_s, dv_s = madv_s(u, v, scheme=scheme)
+        du_c, dv_c = madv_c(u, v, scheme=scheme)
+        # 1-degree lat band → cos varies by O(1e-4); tolerances set
+        # conservatively because the compound operator accumulates a
+        # few reciprocal-cosine factors.
+        np.testing.assert_allclose(
+            du_s[2:-2, 2:-2],
+            du_c[2:-2, 2:-2],
+            rtol=5e-3,
+            atol=5e-3,
+        )
+        np.testing.assert_allclose(
+            dv_s[2:-2, 2:-2],
+            dv_c[2:-2, 2:-2],
+            rtol=5e-3,
+            atol=5e-3,
+        )
+
+    def test_jit(self, madv, grid):
+        key = jax.random.PRNGKey(3)
+        k1, k2 = jax.random.split(key)
+        u = jax.random.normal(k1, (grid.Ny, grid.Nx))
+        v = jax.random.normal(k2, (grid.Ny, grid.Nx))
+        du, dv = jax.jit(lambda a, b: madv(a, b, scheme="al"))(u, v)
+        assert jnp.all(jnp.isfinite(du))
+        assert jnp.all(jnp.isfinite(dv))
+
+    def test_grad(self, madv, grid):
+        key = jax.random.PRNGKey(4)
+        k1, k2 = jax.random.split(key)
+        u = jax.random.normal(k1, (grid.Ny, grid.Nx))
+        v = jax.random.normal(k2, (grid.Ny, grid.Nx))
+
+        def loss(a, b):
+            du, dv = madv(a, b, scheme="energy")
+            return (du**2 + dv**2).sum()
+
+        gu, gv = jax.grad(loss, argnums=(0, 1))(u, v)
+        assert gu.shape == u.shape and gv.shape == v.shape
+        assert jnp.all(jnp.isfinite(gu)) and jnp.all(jnp.isfinite(gv))
+
+
+class TestSphericalMomentumAdvection2DMasked:
+    def test_all_dry_zero(self, grid):
+        all_dry = Mask2D.from_mask(np.zeros((grid.Ny, grid.Nx), dtype=bool))
+        madv = SphericalMomentumAdvection2D(grid=grid, mask=all_dry)
+        key = jax.random.PRNGKey(5)
+        k1, k2 = jax.random.split(key)
+        u = jax.random.normal(k1, (grid.Ny, grid.Nx))
+        v = jax.random.normal(k2, (grid.Ny, grid.Nx))
+        du, dv = madv(u, v, scheme="al")
+        np.testing.assert_allclose(du, 0.0, atol=1e-12)
+        np.testing.assert_allclose(dv, 0.0, atol=1e-12)
+
+    def test_all_wet_matches_unmasked(self, grid):
+        all_wet = Mask2D.from_mask(np.ones((grid.Ny, grid.Nx), dtype=bool))
+        madv_m = SphericalMomentumAdvection2D(grid=grid, mask=all_wet)
+        madv_u = SphericalMomentumAdvection2D(grid=grid)
+        key = jax.random.PRNGKey(6)
+        k1, k2 = jax.random.split(key)
+        u = jax.random.normal(k1, (grid.Ny, grid.Nx))
+        v = jax.random.normal(k2, (grid.Ny, grid.Nx))
+        du_m, dv_m = madv_m(u, v, scheme="energy")
+        du_u, dv_u = madv_u(u, v, scheme="energy")
+        np.testing.assert_allclose(du_m, du_u, atol=1e-12)
+        np.testing.assert_allclose(dv_m, dv_u, atol=1e-12)
+
+    def test_dry_face_zero(self, grid):
+        """A dry U-face and a dry V-face get zero tendency."""
+        m = np.ones((grid.Ny, grid.Nx), dtype=bool)
+        m[4, 5] = False
+        madv = SphericalMomentumAdvection2D(grid=grid, mask=Mask2D.from_mask(m))
+        key = jax.random.PRNGKey(7)
+        k1, k2 = jax.random.split(key)
+        u = jax.random.normal(k1, (grid.Ny, grid.Nx))
+        v = jax.random.normal(k2, (grid.Ny, grid.Nx))
+        du, dv = madv(u, v, scheme="energy")
+        # mask.u[j,i] is False wherever h[j,i] or h[j,i+1] is dry.
+        mu = Mask2D.from_mask(m).u
+        mv = Mask2D.from_mask(m).v
+        # tendency must vanish exactly where the respective mask is False
+        assert jnp.all(du[~mu.astype(bool)] == 0.0)
+        assert jnp.all(dv[~mv.astype(bool)] == 0.0)
+
+
+# ======================================================================
+# SphericalMomentumAdvection3D
+# ======================================================================
+
+
+class TestSphericalMomentumAdvection3D:
+    @pytest.fixture
+    def madv(self, grid3d):
+        return SphericalMomentumAdvection3D(grid=grid3d)
+
+    def test_output_shapes(self, madv, grid3d):
+        shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+        u = jnp.zeros(shape)
+        v = jnp.zeros(shape)
+        du, dv = madv(u, v)
+        assert du.shape == shape
+        assert dv.shape == shape
+
+    def test_zero_velocity_zero_tendency(self, madv, grid3d):
+        shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+        u = jnp.zeros(shape)
+        v = jnp.zeros(shape)
+        du, dv = madv(u, v, scheme="al")
+        np.testing.assert_allclose(du, 0.0, atol=1e-12)
+        np.testing.assert_allclose(dv, 0.0, atol=1e-12)
+
+    def test_z_ghost_slices_zero(self, madv, grid3d):
+        key = jax.random.PRNGKey(8)
+        k1, k2 = jax.random.split(key)
+        shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+        u = jax.random.normal(k1, shape)
+        v = jax.random.normal(k2, shape)
+        du, dv = madv(u, v, scheme="energy")
+        np.testing.assert_allclose(du[0], 0.0, atol=1e-10)
+        np.testing.assert_allclose(du[-1], 0.0, atol=1e-10)
+        np.testing.assert_allclose(dv[0], 0.0, atol=1e-10)
+        np.testing.assert_allclose(dv[-1], 0.0, atol=1e-10)
+
+    def test_matches_2d_per_level(self, madv, grid3d):
+        madv2 = SphericalMomentumAdvection2D(grid=grid3d.horizontal_grid())
+        key = jax.random.PRNGKey(9)
+        k1, k2 = jax.random.split(key)
+        u2 = jax.random.normal(k1, (grid3d.Ny, grid3d.Nx))
+        v2 = jax.random.normal(k2, (grid3d.Ny, grid3d.Nx))
+        shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+        u3 = jnp.broadcast_to(u2, shape)
+        v3 = jnp.broadcast_to(v2, shape)
+        du2, dv2 = madv2(u2, v2, scheme="al")
+        du3, dv3 = madv(u3, v3, scheme="al")
+        for k in range(1, grid3d.Nz - 1):
+            np.testing.assert_allclose(du3[k], du2, atol=1e-12)
+            np.testing.assert_allclose(dv3[k], dv2, atol=1e-12)
+
+    def test_masked_all_dry_zero(self, grid3d):
+        all_dry = Mask3D.from_mask(
+            np.zeros((grid3d.Nz, grid3d.Ny, grid3d.Nx), dtype=bool)
+        )
+        madv = SphericalMomentumAdvection3D(grid=grid3d, mask=all_dry)
+        key = jax.random.PRNGKey(10)
+        k1, k2 = jax.random.split(key)
+        shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+        u = jax.random.normal(k1, shape)
+        v = jax.random.normal(k2, shape)
+        du, dv = madv(u, v, scheme="energy")
+        np.testing.assert_allclose(du, 0.0, atol=1e-12)
+        np.testing.assert_allclose(dv, 0.0, atol=1e-12)
+
+    def test_jit_grad(self, madv, grid3d):
+        key = jax.random.PRNGKey(11)
+        k1, k2 = jax.random.split(key)
+        shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+        u = jax.random.normal(k1, shape)
+        v = jax.random.normal(k2, shape)
+        du, dv = jax.jit(lambda a, b: madv(a, b, scheme="energy"))(u, v)
+        assert jnp.all(jnp.isfinite(du)) and jnp.all(jnp.isfinite(dv))
+
+        def loss(a, b):
+            du_, dv_ = madv(a, b, scheme="al")
+            return (du_**2 + dv_**2).sum()
+
+        gu, gv = jax.grad(loss, argnums=(0, 1))(u, v)
+        assert jnp.all(jnp.isfinite(gu)) and jnp.all(jnp.isfinite(gv))


### PR DESCRIPTION
## Summary

Addresses the three spherical-operator follow-ups opened after PR #216 in a single stacked PR. Based on branch \`feat/spherical-diffusion-advection-165\` (PR #216); retargeted to \`main\` automatically once that lands.

| Issue | Deliverable |
|-------|------------|
| #217  | \`SphericalBiharmonicDiffusion2D/3D\` — scale-selective ∇⁴ dissipation on a sphere |
| #218  | \`SphericalMomentumAdvection2D/3D\` — vector-invariant spherical momentum advection with the three Sadourny / Arakawa–Lamb schemes |
| #219  | Area/volume-weighted reduction helpers (\`area_sum\`/\`mean\`, \`volume_sum\`/\`mean\`) with Cartesian/spherical dispatch |

## #217 — Biharmonic spherical diffusion

Added to [spherical_diffusion.py](finitevolx/_src/diffusion/spherical_diffusion.py): two ``SphericalDiffusion`` passes ⇒ ``−κ · ∇⁴_sphere h``. Inner harmonic always ``mask=None``; outer mask applied on the final tendency (the #209 §4 exception is identical on a sphere). 3-D variant vmaps over z.

## #218 — Spherical momentum advection

New file [spherical_momentum.py](finitevolx/_src/diffusion/spherical_momentum.py). Algorithm mirrors ``MomentumAdvection2D``: curl via ``SphericalVorticity2D``, KE gradients via ``SphericalDifference2D``, three flux schemes (``energy`` / ``enstrophy`` / ``al``) are coordinate-independent. Pass-down masking + final ``* mask.u`` / ``* mask.v``; 3-D Pattern A wrapper.

## #219 — Area/volume-weighted reductions

New file [reductions.py](finitevolx/_src/operators/reductions.py). Polymorphic dispatchers:

* ``area_sum(field, grid, mask=None)`` / ``area_mean`` / ``volume_sum`` / ``volume_mean``
* ``cartesian_*`` / ``spherical_*`` explicit per-coordinate aliases
* ``area_weights`` / ``volume_weights`` for users who want the metric arrays directly

Spherical area ``R² · cos(lat_T) · dlon · dlat`` with a near-pole guard (weight = 0 where ``|cos| < 1e-12``). Means return NaN when the total wet area/volume is zero.

## Test plan

- [x] 17 new tests in \`test_spherical_diffusion.py\` for biharmonic (shape, constant-field invariance, sign-of-tendency dissipation check, Cartesian equatorial-limit match, per-cell masking, JIT/grad)
- [x] 21 new tests in \`test_spherical_momentum.py\` (shapes, zero-velocity zero tendency, all three schemes finite, invalid-scheme raises, Cartesian equatorial-limit match for each scheme, masking, 2-D vs 3-D per-level, JIT/grad)
- [x] 25 new tests in \`test_reductions.py\` (metric arrays, constant-field area-sum, full-sphere ≈ 4πR² integral, refinement reduces error, Cartesian vs spherical narrow-band equivalence, ghost ring ignored, mask exclusion, all-dry → NaN mean, JIT/grad, 3-D volume sums)
- [x] Full suite: **1961 tests pass**
- [x] \`ruff check .\`, \`ruff format --check .\`, \`ty check finitevolx\` — all clean

## Public API additions

\`\`\`python
# Diffusion
SphericalBiharmonicDiffusion2D, SphericalBiharmonicDiffusion3D

# Momentum advection
SphericalMomentumAdvection2D, SphericalMomentumAdvection3D

# Reductions
area_weights, area_sum, area_mean
volume_weights, volume_sum, volume_mean
cartesian_area_weights/sum/mean, cartesian_volume_weights/sum/mean
spherical_area_weights/sum/mean, spherical_volume_weights/sum/mean
\`\`\`

Closes #217, #218, #219.