### PR TITLE
feat: boundary_ring, SolveDomain, KnownValueLifting for inhomogeneous BCs

### DIFF
--- a/docs/design/research/boundaries/inhomogeneous_bcs_current.md
+++ b/docs/design/research/boundaries/inhomogeneous_bcs_current.md
@@ -358,7 +358,7 @@ At dry boundary cells: $\psi = g + 0$ (the prescribed data).
 | `Dirichlet1D(value=g)` | `bc_1d.py:68-93` | Already carries non-zero values; can be expanded from per-face to per-cell |
 | `BoundaryConditionSet` | `bc_set.py:11-66` | Natural container to pass 4-face Dirichlet data to a solver |
 | `masked_laplacian` | `iterative.py:144-191` | Step 3 of the lift already uses this; no new operator needed |
-| `_solve_dispatch` | `elliptic.py:253-273` | Central routing point; a `bc_values=` kwarg can be added here |
+| `_solve_dispatch` | `elliptic.py:253-273` | Central routing point; `known_values`/`known_mask` kwargs can be added here |
 | `modify_rhs_2d` | `spectral.py:49` (re-export) | Spectral-path inhomogeneous BCs; already available but unused |
 | `_inner_boundary_indices` | `tests/test_solver_wrappers.py:47-54` | SciPy-based helper for finding boundary ring; candidate for JAX-native port |
 | `pv_inversion` vmap logic | `elliptic.py:437-542` | Multi-layer batching that the lift must integrate with |

--- a/docs/design/research/boundaries/inhomogeneous_bcs_current.md
+++ b/docs/design/research/boundaries/inhomogeneous_bcs_current.md
@@ -1,0 +1,369 @@
+# Inhomogeneous Boundary Conditions in finitevolX: Current State
+
+This document describes how finitevolX handles boundary conditions today,
+highlights the gap between the time-stepping BC vocabulary and the elliptic
+solver layer, and walks through the manual lifting-trick workaround for
+non-zero Dirichlet data.
+
+**Companion document:** [inhomogeneous_bcs_design.md](./inhomogeneous_bcs_design.md)
+proposes a future API that closes this gap.
+
+**GitHub issue:** [jejjohnson/finitevolX#186](https://github.com/jejjohnson/finitevolX/issues/186)
+
+---
+
+## 1. When Non-Zero Boundary Data Arises
+
+| Use case | Boundary data source |
+|----------|---------------------|
+| **Regional nesting** | Parent model provides SSH/streamfunction at open boundaries |
+| **Data assimilation** | Tide gauges or satellite altimetry fix boundary values |
+| **Reanalysis-forced runs** | ERA5 or ORAS5 SSH prescribed at lateral boundaries |
+| **Two-way coupling** | Outer model provides BCs for an inner high-resolution domain |
+| **Manufactured solutions** | Testing with non-trivial exact solutions that don't vanish at boundaries |
+
+All of these require solving $(A - \lambda)\psi = f$ with $\psi = g$ on the
+boundary, where $g \neq 0$.
+
+---
+
+## 2. What finitevolX Already Has: The Ghost-Cell BC System
+
+The boundary module (`finitevolx/_src/boundary/`) provides a rich, composable
+set of BC objects built on the ghost-cell paradigm.  All arrays have shape
+`(Ny, Nx)` with an outermost one-cell ghost ring; the physical boundary lies
+between the first interior cell and the ghost cell.
+
+### 2.1 Single-Face BC Atoms (`bc_1d.py`)
+
+Nine BC types, all `equinox.Module` subclasses with a common signature:
+
+```python
+bc = SomeBCType(face="south", ...)
+field_updated = bc(field, dx=dx, dy=dy)  # returns field with one ghost face set
+```
+
+| BC Type | Class | Ghost-cell formula | Typical use |
+|---------|-------|--------------------|-------------|
+| Dirichlet | `Dirichlet1D` | `ghost = 2*value - interior` | Fixed wall value ($\psi = 0$, $u = 0$) |
+| Neumann | `Neumann1D` | `ghost = interior + sign*value*spacing` | Zero normal gradient (free-slip, no-flux) |
+| Periodic | `Periodic1D` | `ghost = opposite_interior` | Doubly-periodic channels |
+| Outflow | `Outflow1D` | `ghost = interior` | Open boundary (zero gradient) |
+| Reflective | `Reflective1D` | `ghost = interior` | Even symmetry (Neumann with $g = 0$) |
+| Sponge | `Sponge1D` | `ghost = (1-w)*interior + w*background` | Wave absorption |
+| Robin | `Robin1D` | $\alpha u + \beta \partial u/\partial n = \gamma$ | Mixed BC |
+| Extrapolation | `Extrapolation1D` | Lagrange polynomial (orders 1--5) | Smooth open boundaries |
+| Slip | `Slip1D` | `ghost = (2a-1)*interior` | Partial-slip walls ($a \in [0,1]$) |
+
+**Key point:** `Dirichlet1D` already accepts a non-zero `value=g`:
+
+```python
+from finitevolx import Dirichlet1D
+
+# Non-zero Dirichlet: ψ = 0.5 on the south wall
+bc_south = Dirichlet1D(face="south", value=0.5)
+psi = bc_south(psi, dx=dx, dy=dy)
+# ghost[0, :] = 2*0.5 - psi[1, :] = 1.0 - psi[1, :]
+```
+
+### 2.2 Per-Face Containers (`bc_set.py`)
+
+`BoundaryConditionSet` composes one atom per face (south, north, west, east):
+
+```python
+from finitevolx import BoundaryConditionSet, Dirichlet1D, Periodic1D
+
+bc_set = BoundaryConditionSet(
+    south=Dirichlet1D(face="south", value=0.0),
+    north=Dirichlet1D(face="north", value=0.0),
+    west=Periodic1D(face="west"),
+    east=Periodic1D(face="east"),
+)
+psi = bc_set(psi, dx=dx, dy=dy)  # all four faces updated
+```
+
+Application order: south -> north -> west -> east (west/east overwrite corners).
+
+Factory methods for common patterns:
+
+```python
+BoundaryConditionSet.periodic()  # all four faces periodic
+BoundaryConditionSet.open()      # all four faces zero-gradient outflow
+```
+
+### 2.3 Multi-Field Dispatch (`bc_field.py`)
+
+`FieldBCSet` applies different BC sets to different state-dictionary entries:
+
+```python
+from finitevolx import FieldBCSet
+
+field_bcs = FieldBCSet(
+    bc_map={"psi": bc_closed_basin, "eta": bc_open_boundary},
+    default=BoundaryConditionSet.periodic(),
+)
+state_out = field_bcs(state_dict, dx=dx, dy=dy)
+```
+
+### 2.4 Functional Helpers (`boundary.py`)
+
+Quick one-liners for common homogeneous patterns:
+
+| Function | Effect |
+|----------|--------|
+| `zero_boundaries(field)` | Homogeneous Dirichlet ($\psi = 0$) on all faces |
+| `zero_gradient_boundaries(field)` | Homogeneous Neumann ($\partial\psi/\partial n = 0$) |
+| `no_flux_boundaries(field)` | Alias for `zero_boundaries` (normal flux = 0) |
+| `no_slip_boundaries(field)` | Tangential velocity = 0 (ghost = $-$interior) |
+| `free_slip_boundaries(field)` | Zero normal gradient (ghost = interior) |
+| `enforce_periodic(field)` | Periodic wrapping in x and/or y |
+| `wall_boundaries(field, stag)` | C-grid composite: picks correct BC per staggering (`h`/`u`/`v`/`q`) |
+
+---
+
+## 3. What the Elliptic Solvers Accept
+
+The three convenience wrappers live in `finitevolx/_src/solvers/elliptic.py`:
+
+```python
+# Streamfunction from vorticity: ∇²ψ − λψ = ζ
+psi = fvx.streamfunction_from_vorticity(
+    zeta, dx, dy,
+    bc="dst",              # ← a STRING, not a BC object
+    lambda_=0.0,
+    method="spectral",     # or "cg" or "capacitance"
+    mask=None,
+    capacitance_solver=None,
+    preconditioner=None,
+)
+
+# Pressure from divergence: ∇²p = ∇·u
+p = fvx.pressure_from_divergence(div_u, dx, dy, bc="dct")
+
+# PV inversion: (∇² − λ)ψ = q  (multi-layer / batched)
+psi = fvx.pv_inversion(pv, dx, dy, lambda_=lam, bc="dst")
+```
+
+### The `bc=` parameter is a transform selector, not a BC object
+
+| `bc` value | Transform | Implicit boundary condition |
+|------------|-----------|----------------------------|
+| `"dst"` | Discrete Sine Transform | Homogeneous Dirichlet ($\psi = 0$) |
+| `"dct"` | Discrete Cosine Transform | Homogeneous Neumann ($\partial\psi/\partial n = 0$) |
+| `"fft"` | Fast Fourier Transform | Periodic |
+
+All three call the same internal dispatcher (`_solve_dispatch`, line 253),
+which routes to one of:
+
+- **Spectral** (`_solve_spectral`): calls `spectraldiffx`'s `solve_helmholtz_dst/dct/fft`
+- **CG** (`_solve_cg_method`): uses `masked_laplacian` as the `matvec` operator
+- **Capacitance** (`_solve_capacitance_method`): calls a pre-built `CapacitanceSolver`
+
+Plus the **multigrid** path, accessible through `build_multigrid_solver` ->
+`make_multigrid_preconditioner` -> CG.
+
+### All four solver methods enforce homogeneous BCs
+
+**Masked Laplacian** (`iterative.py:144-191`):
+
+```python
+def masked_laplacian(psi, mask, dx, dy, lambda_=0.0):
+    psi_m = psi * mask_arr          # ← zero outside domain
+    lap = (
+        jnp.roll(psi_m, 1, axis=1) + jnp.roll(psi_m, -1, axis=1) - 2.0 * psi_m
+    ) / dx**2 + (
+        jnp.roll(psi_m, 1, axis=0) + jnp.roll(psi_m, -1, axis=0) - 2.0 * psi_m
+    ) / dy**2
+    return (lap - lambda_ * psi_m) * mask_arr  # ← zero outside domain
+```
+
+The two `* mask_arr` operations hard-wire $\psi = 0$ at the mask boundary.
+There is no parameter to inject non-zero boundary values.
+
+**Capacitance solver:** Enforces $\psi = 0$ at all inner-boundary points
+(ocean cells adjacent to land) through the Sherman-Morrison correction.
+
+**Multigrid operator** (`multigrid.py:327-410`): Zeroes the face coefficients
+`cx`/`cy` at the mask edge, baking homogeneous Dirichlet into the precomputed
+level hierarchy.
+
+### Unsurfaced prior art: `modify_rhs_*` from spectraldiffx
+
+`spectraldiffx` already ships `modify_rhs_1d`, `modify_rhs_2d`, and
+`modify_rhs_3d` for encoding inhomogeneous BC values into the RHS of a
+spectral solve.  finitevolX re-exports them (`spectral.py:48-50`) but **none
+of the convenience wrappers surface them** -- they sit unused in the public API.
+
+---
+
+## 4. The Gap
+
+The BC vocabulary is **rich on one side** (9 atom types, per-face composition,
+multi-field dispatch, non-zero `value=` support) and **a single string on the
+other** (the `bc="dst"` parameter on the elliptic wrappers).
+
+```
+Time-stepping BCs              Elliptic solver BCs
+──────────────────              ──────────────────
+Dirichlet1D(value=g)           bc="dst" → ψ=0
+Neumann1D(value=g)             bc="dct" → ∂ψ/∂n=0
+Robin1D(α, β, γ)               bc="fft" → periodic
+Sponge1D(bg, weight)           (nothing)
+Slip1D(coefficient)            (nothing)
+BoundaryConditionSet           (nothing)
+FieldBCSet                     (nothing)
+```
+
+Non-zero boundary data has nowhere to go.  Users who need $\psi = g \neq 0$
+must hand-roll the **lifting trick**.
+
+---
+
+## 5. Worked Example: The Lifting Trick Today
+
+This is the workflow from `docs/notebooks/demo_solvers.py`, Section 8
+(lines 944--1087).  It solves the Helmholtz equation on a basin domain with
+prescribed non-zero Dirichlet data: $\psi = g$ on the boundary, where
+$g(y) = 0.1 \sin(2\pi y / L_y)$.
+
+### The Decomposition
+
+$$
+\psi = \psi_{\text{lift}} + \psi_{\text{hom}}
+$$
+
+where $\psi_{\text{lift}}$ matches the prescribed boundary data $g$, and
+$\psi_{\text{hom}}$ solves the **corrected** equation with **zero** BCs:
+
+$$
+(A - \lambda)\,\psi_{\text{hom}} = f - (A - \lambda)\,\psi_{\text{lift}},
+\qquad \psi_{\text{hom}} = 0 \;\text{on boundary}
+$$
+
+### Step 1: Identify the boundary cells
+
+The "boundary cells" for the lift are the **dry cells adjacent to at least one
+wet cell** -- the 1-cell-wide land ring around the ocean.
+
+```python
+from scipy.ndimage import binary_dilation
+
+wet = mask_basin.astype(bool)
+wet_dilated = binary_dilation(wet)
+dry_boundary = wet_dilated & ~wet
+```
+
+### Step 2: Build the lifting function
+
+Place the prescribed values at dry boundary cells, zero elsewhere:
+
+```python
+import numpy as np
+
+g_field = 0.1 * np.sin(2 * np.pi * Y / Ny)
+
+psi_lift = np.zeros((Ny, Nx))
+psi_lift[dry_boundary] = g_field[dry_boundary]
+psi_lift_jnp = jnp.array(psi_lift)
+```
+
+### Step 3: Correct the RHS
+
+Subtract the operator applied to the lift at wet cells:
+
+```python
+A_psi_lift = fvx.masked_laplacian(
+    psi_lift_jnp, mask_basin_jnp, dx, dy, lambda_=lambda_
+)
+rhs_corrected = rhs_basin - A_psi_lift
+```
+
+### Step 4: Solve the homogeneous problem
+
+Any solver works here -- the lift only changed the RHS:
+
+```python
+sol_cg_inhom, info_inhom = fvx.solve_cg(
+    A_basin, rhs_corrected,
+    preconditioner=pc_basin,
+    rtol=1e-10, atol=1e-10,
+)
+sol_cg_inhom = sol_cg_inhom * mask_basin_jnp  # zero outside
+```
+
+### Step 5: Reconstruct the full solution
+
+```python
+psi_full_inhom = psi_lift_jnp + sol_cg_inhom
+```
+
+At wet cells: $\psi = 0 + \psi_{\text{hom}}$ (the solver result).
+At dry boundary cells: $\psi = g + 0$ (the prescribed data).
+
+### Summary table
+
+| Step | Operation | Code |
+|------|-----------|------|
+| 1 | Find boundary ring | `dry_boundary = binary_dilation(wet) & ~wet` |
+| 2 | Build $\psi_{\text{lift}}$ | `psi_lift[dry_boundary] = g[dry_boundary]` |
+| 3 | Correct RHS | `rhs' = rhs - masked_laplacian(psi_lift, ...)` |
+| 4 | Solve homogeneous | `psi_hom = solver(rhs')` |
+| 5 | Reconstruct | `psi = psi_lift + psi_hom` |
+
+---
+
+## 6. Pain Points With the Manual Approach
+
+1. **Users must know which cells are "boundary".**  The lift lives at *dry
+   cells adjacent to wet*, not the coast ring itself.  Getting this wrong
+   silently produces garbage.
+
+2. **The dilation requires SciPy.**  `scipy.ndimage.binary_dilation` is a
+   NumPy operation that cannot be JIT-compiled.  In a time-stepping loop
+   where $g$ changes every step, the mask work must be hoisted outside the
+   JIT boundary -- which is non-obvious.
+
+3. **The masked Laplacian must be reapplied to the lift.**  Step 3 is easy
+   to forget or get wrong (e.g. applying the bare Laplacian instead of the
+   Helmholtz operator, or forgetting the mask).
+
+4. **Reconstruction is a separate step.**  Step 5 is trivial but easy to
+   forget, especially in a multi-layer `pv_inversion` loop where each layer
+   needs its own lift.
+
+5. **No spectral-path equivalent.**  The lifting trick as written above
+   works only with CG/capacitance/multigrid (all mask-based).  For the
+   spectral path on a rectangular domain, the correct approach is to
+   encode the inhomogeneous data via `modify_rhs_2d` from `spectraldiffx`
+   -- but the convenience wrappers don't expose this, so users have to
+   drop down to the raw spectral API.
+
+6. **No connection to the BC vocabulary.**  A user who writes
+   `Dirichlet1D(face="west", value=0.5)` for time-stepping has no way to
+   feed that same information to `streamfunction_from_vorticity`.  The two
+   systems are completely disconnected.
+
+7. **Multi-layer PV inversion is particularly painful.**  `pv_inversion`
+   accepts a `lambda_` array for per-layer Helmholtz parameters and handles
+   the `vmap` internally -- but the user must replicate that batching logic
+   externally to apply the lift per layer, defeating the purpose of the
+   convenience wrapper.
+
+---
+
+## 7. Existing Infrastructure That a Future API Can Reuse
+
+| Component | Location | Reuse potential |
+|-----------|----------|----------------|
+| `Dirichlet1D(value=g)` | `bc_1d.py:68-93` | Already carries non-zero values; can be expanded from per-face to per-cell |
+| `BoundaryConditionSet` | `bc_set.py:11-66` | Natural container to pass 4-face Dirichlet data to a solver |
+| `masked_laplacian` | `iterative.py:144-191` | Step 3 of the lift already uses this; no new operator needed |
+| `_solve_dispatch` | `elliptic.py:253-273` | Central routing point; a `bc_values=` kwarg can be added here |
+| `modify_rhs_2d` | `spectral.py:49` (re-export) | Spectral-path inhomogeneous BCs; already available but unused |
+| `_inner_boundary_indices` | `tests/test_solver_wrappers.py:47-54` | SciPy-based helper for finding boundary ring; candidate for JAX-native port |
+| `pv_inversion` vmap logic | `elliptic.py:437-542` | Multi-layer batching that the lift must integrate with |
+
+---
+
+*See [inhomogeneous_bcs_design.md](./inhomogeneous_bcs_design.md) for the
+proposed API that addresses these pain points.*

--- a/docs/design/research/boundaries/inhomogeneous_bcs_design.md
+++ b/docs/design/research/boundaries/inhomogeneous_bcs_design.md
@@ -1,458 +1,554 @@
-# Inhomogeneous Boundary Conditions in finitevolX: Future API Design
+# Unified Boundary Conditions in finitevolX: Design Document
 
-This document proposes a layered API for **inhomogeneous (non-zero) Dirichlet
-boundary conditions** on finitevolX's elliptic solvers, responding to
-[jejjohnson/finitevolX#186](https://github.com/jejjohnson/finitevolX/issues/186).
+This document proposes a **unified boundary condition system** for finitevolX
+that works across time-stepping, direct state application, and elliptic
+solvers — with first-class support for **known values** at any cell (outer
+boundaries, island coasts, and sparse interior observations).
+
+Responds to [jejjohnson/finitevolX#186](https://github.com/jejjohnson/finitevolX/issues/186).
 
 **Companion document:** [inhomogeneous_bcs_current.md](./inhomogeneous_bcs_current.md)
-describes the current state and the manual lifting trick.
+describes the current state and the manual lifting-trick workaround.
 
 ---
 
 ## 1. Goal
 
-Support solving $(A - \lambda)\psi = f$ with $\psi = g$ on the boundary
-($g \neq 0$), where:
+A unified boundary condition system for finitevolX that:
 
-- The solution is **JIT-compilable** and **vmap-compatible** (including
-  time-varying $g$).
-- It **composes with all four solver methods**: spectral, CG, capacitance,
-  and multigrid.
-- It causes **zero behavior change** for existing call sites that don't pass
-  boundary data.
-- It **bridges** the existing `Dirichlet1D` / `BoundaryConditionSet`
-  vocabulary from the time-stepping BC layer to the elliptic solver layer.
-
----
-
-## 2. Design Principles
-
-1. **Reuse, don't reinvent.**  The `Dirichlet1D`, `BoundaryConditionSet`, and
-   `masked_laplacian` APIs already exist.  The new code should call them,
-   not duplicate their logic.
-
-2. **The lifting trick is the implementation, not the API.**  Users should
-   never write `binary_dilation` or manually compute the corrected RHS.
-   That logic is encapsulated behind a single entry point.
-
-3. **JAX-native throughout.**  Replace the SciPy `binary_dilation` from the
-   demo notebook with a JAX-native one-cell dilation (XOR of mask shifts),
-   so the entire path is JIT-friendly without a NumPy round-trip.
-
-4. **One implementation, three layers of API.**  The lifting logic is written
-   once (Layer 1, a pure function).  Layers 2 and 3 are thin wrappers that
-   call Layer 1.
-
-5. **Additive, not breaking.**  All new parameters have default `None`, so
-   existing call sites remain unchanged.
+- **Works everywhere** — time-stepping (ghost-cell updates), direct state
+  application, and elliptic solvers, all through the same BC object.
+- **Carries domain geometry** — the `BoundaryConditionSet` owns a `Mask2D`,
+  so solvers don't need a separate mask argument.
+- **Supports known values at any cell** — outer boundaries, island coasts
+  (auto-derived from mask topology), and sparse interior observations
+  (user-supplied `known_mask`).
+- **Is JIT-compilable and vmap-compatible**, including time-varying known
+  values.
+- **Causes zero breakage** for existing call sites — all new fields default
+  to `None`.
 
 ---
 
-## 3. Recommended Design: Three Layers
+## 2. Unified BC and BCSet Design
 
-### Layer 1 -- Pure Function: `apply_inhomogeneous_bc`
+### 2.1 BC Atoms (unchanged)
 
-The foundation.  A composable pure function that performs the lifting trick
-and returns the corrected RHS + lift array.
+The existing 9 atom types in `bc_1d.py` remain as-is.  They are face-level
+building blocks with no mask awareness:
 
 ```python
-from finitevolx import apply_inhomogeneous_bc
+# These stay exactly the same
+Dirichlet1D(face="south", value=0.0)
+Neumann1D(face="west", value=0.0)
+Robin1D(face="north", alpha=1.0, beta=0.5, gamma=0.0)
+Periodic1D(face="east")
+# ... plus Outflow1D, Reflective1D, Sponge1D, Extrapolation1D, Slip1D
+```
 
-rhs_corrected, psi_lift = apply_inhomogeneous_bc(
-    rhs=rhs,
-    bc_values=g,          # (Ny, Nx) array; only dry-boundary values matter
-    mask=mask,            # (Ny, Nx) binary mask (1=wet, 0=dry)
-    dx=dx, dy=dy,
-    lambda_=0.0,
+No mask on individual atoms — they describe *what kind* of condition applies
+on a face, not *where* the domain is.
+
+### 2.2 BoundaryConditionSet (evolved)
+
+The existing `BoundaryConditionSet` (`bc_set.py`) gains three new optional
+fields:
+
+```python
+class BoundaryConditionSet(eqx.Module):
+    # --- Existing fields (unchanged) ---
+    south: BoundaryCondition1D | None = None
+    north: BoundaryCondition1D | None = None
+    west: BoundaryCondition1D | None = None
+    east: BoundaryCondition1D | None = None
+
+    # --- NEW fields ---
+    mask: Mask2D | Float[Array, "Ny Nx"] | None = None
+    known_values: Float[Array, "Ny Nx"] | None = None
+    known_mask: Bool[Array, "Ny Nx"] | None = None
+```
+
+All new fields default to `None`, so every existing call site continues to
+work unchanged.
+
+#### Mask ownership
+
+- The BCSet owns a `Mask2D` (or raw float array).
+- When a `Mask2D` is provided, each atom can extract the correct staggering
+  internally (h/u/v/q) — the atom knows its face, the `Mask2D` knows the
+  geometry.
+- Solver operators read the mask from the BCSet — the user doesn't pass it
+  separately.
+- `mask=None` for simple rectangular domains (backward compatible).
+
+#### Known values
+
+- `known_values`: `(Ny, Nx)` array of prescribed values.  Only cells
+  identified as "known" are read; values at other cells are ignored.
+- `known_mask`: `(Ny, Nx)` boolean array marking **explicit** known-value
+  locations (e.g., sparse observations at interior wet cells).
+- Both are optional.  When absent, behavior is identical to today.
+
+#### Auto-derive + merge
+
+The set of "known cells" is computed by combining two sources:
+
+```
+# 1. Auto-derive boundary cells from mask topology
+#    (outer boundary ring + island coast rings)
+boundary_cells = _dilate(wet_mask) & ~wet_mask
+
+# 2. Merge with explicit known_mask (sparse obs, etc.)
+if known_mask is not None:
+    all_known = boundary_cells | known_mask
+else:
+    all_known = boundary_cells
+```
+
+This handles three scenarios transparently:
+
+```
+Scenario 1: Simple basin         Scenario 2: Basin + island      Scenario 3: + sparse observations
+
+0 0 0 0 0 0 0 0                  0 0 0 0 0 0 0 0                 0 0 0 0 0 0 0 0
+0 . . . . . . 0                  0 . . . . . . 0                 0 . . . . . . 0
+0 . . . . . . 0                  0 . . 0 0 . . 0                 0 . . . . . . 0
+0 . . . . . . 0                  0 . . 0 0 . . 0                 0 . X . . X . 0
+0 . . . . . . 0                  0 . . . . . . 0                 0 . . . . . . 0
+0 . . . . . . 0                  0 . . . . . . 0                 0 . . . X . . 0
+0 0 0 0 0 0 0 0                  0 0 0 0 0 0 0 0                 0 0 0 0 0 0 0 0
+
+0 = land (dry)                   0 = land (dry + island)          X = observation (known interior)
+. = ocean (wet, solve here)      . = ocean (wet, solve here)      . = ocean (wet, solve here)
+
+known_mask: not needed           known_mask: not needed           known_mask: marks X cells
+Auto-derive finds outer ring     Auto-derive finds outer +        Auto-derive + merge with
+                                 island rings                     user-supplied known_mask
+```
+
+In all three cases, the solver:
+1. Identifies all known cells (boundary ring + explicit `known_mask`)
+2. Places `known_values` at those cells (the "lift")
+3. Shrinks the solve domain: `effective_solve_mask = wet & ~all_known`
+4. Corrects the RHS and solves the homogeneous problem on the reduced domain
+
+#### Unified interface
+
+```python
+bc = BoundaryConditionSet(
+    mask=cgrid_mask,
+    south=Dirichlet1D("south", value=0.0),
+    north=Dirichlet1D("north", value=0.1),
+    west=Neumann1D("west", value=0.0),
+    east=Dirichlet1D("east", value=0.05),
+    known_values=obs_field,       # optional: (Ny, Nx) prescribed values
+    known_mask=obs_locations,     # optional: (Ny, Nx) where obs apply
 )
 
-# Solve with ANY solver (spectral, CG, capacitance, multigrid)
+# Time-stepping: apply ghost cells as before
+state = bc(state, dx, dy)
+
+# Elliptic solver: mask + known values extracted from bc
+psi = fvx.streamfunction_from_vorticity(zeta, dx, dy, bc=bc)
+```
+
+#### Factory methods (extended)
+
+```python
+# Existing factories still work
+BoundaryConditionSet.periodic()
+BoundaryConditionSet.open()
+
+# New: closed basin with mask
+BoundaryConditionSet.closed(mask=cgrid_mask)
+# → Dirichlet(value=0) on all four faces, mask attached
+```
+
+### 2.3 FieldBCSet (minimal change)
+
+No structural change.  It dispatches per-field `BoundaryConditionSet` as
+before.  Each BCSet in the map can now carry its own mask + known values:
+
+```python
+field_bcs = FieldBCSet(
+    bc_map={
+        "psi": BoundaryConditionSet(mask=mask, south=..., known_values=obs_psi),
+        "eta": BoundaryConditionSet(mask=mask, south=..., known_values=obs_eta),
+    },
+)
+```
+
+---
+
+## 3. Design Principles
+
+1. **Unified vocabulary** — one BC object for time-stepping and solvers.
+   Users write `BoundaryConditionSet(...)` once and use it everywhere.
+
+2. **BCSet owns the mask** — solvers extract it from the BC object; users
+   don't pass the mask separately.
+
+3. **known_values generalizes boundary data** — outer boundary ring, island
+   coasts, and sparse interior observations all flow through the same
+   mechanism.
+
+4. **Auto-derive + merge** — boundary cells are computed from mask topology
+   (JAX-native dilation); merged with any explicit `known_mask`.
+
+5. **The lifting trick is the implementation, not the API** — users never
+   write `binary_dilation` or manually compute corrected RHS.
+
+6. **JAX-native throughout** — no SciPy in the hot path.  The dilation uses
+   `jnp.roll` + boolean OR (~4 rolls).
+
+7. **Additive, not breaking** — all new fields default to `None`.  Every
+   existing call site continues to work unchanged.
+
+---
+
+## 4. Solver Integration: Three Layers
+
+### Layer 1 — Pure Function: `apply_known_values`
+
+The foundation.  A composable pure function that performs the generalized
+lifting trick.  Accepts all parameters explicitly (maximum composability for
+power users who want to bring their own solver).
+
+```python
+from finitevolx import apply_known_values
+
+rhs_corrected, value_lift = apply_known_values(
+    rhs=rhs,
+    known_values=obs_field,     # (Ny, Nx) prescribed values
+    mask=mask,                  # (Ny, Nx) wet/dry mask
+    dx=dx, dy=dy,
+    lambda_=0.0,
+    known_mask=obs_locations,   # optional: explicit obs cells
+)
+
+# Solve with ANY solver
 psi_hom = my_solver(rhs_corrected)
 
 # Reconstruct
-psi = psi_lift + psi_hom
+psi = value_lift + psi_hom
 ```
 
 **What it does internally:**
 
 ```
-1. Compute dry boundary ring (JAX-native dilation):
+1. Auto-derive boundary ring from mask (JAX-native dilation):
    wet = mask > 0.5
-   dilated = wet | roll(wet, +1, axis=0) | roll(wet, -1, axis=0)
-                  | roll(wet, +1, axis=1) | roll(wet, -1, axis=1)
-   dry_boundary = dilated & ~wet
+   dilated = wet | roll(wet, +1, 0) | roll(wet, -1, 0)
+                  | roll(wet, +1, 1) | roll(wet, -1, 1)
+   boundary_cells = dilated & ~wet
 
-2. Build lift:
-   psi_lift = jnp.where(dry_boundary, bc_values, 0.0)
+2. Merge with explicit known_mask:
+   all_known = boundary_cells | known_mask   (if known_mask given)
+   all_known = boundary_cells                (otherwise)
 
-3. Correct RHS:
-   A_lift = masked_laplacian(psi_lift, mask, dx, dy, lambda_)
+3. Build lift:
+   value_lift = jnp.where(all_known, known_values, 0.0)
+
+4. Compute effective solve mask:
+   effective_solve_mask = wet & ~all_known
+
+5. Correct RHS:
+   A_lift = masked_laplacian(value_lift, effective_solve_mask, dx, dy, lambda_)
    rhs_corrected = rhs - A_lift
 
-4. Return (rhs_corrected, psi_lift)
+6. Return (rhs_corrected, value_lift)
 ```
-
-**Key design choices:**
-
-- Returns **both** `rhs_corrected` and `psi_lift` so the caller can
-  reconstruct the full solution.  Returning only the corrected RHS would
-  force users to recompute the lift to add it back.
-- Accepts a full `(Ny, Nx)` array for `bc_values`, not just boundary
-  slices.  Interior values are ignored (masked out by `dry_boundary`).
-  This is simpler and more flexible -- users can pass a full reanalysis
-  field without extracting boundary cells.
-- Uses `masked_laplacian` (`iterative.py:144-191`) for the
-  $A\psi_{\text{lift}}$ step.  No new operator.
-- The JAX-native dilation replaces `scipy.ndimage.binary_dilation`, making
-  the function JIT-compilable.  The mask is static (shape doesn't change),
-  so the dilation is cheap.
-
-**Proposed location:** `finitevolx/_src/solvers/inhomogeneous.py` (new file),
-re-exported from `finitevolx/_src/solvers/elliptic.py` and
-`finitevolx/__init__.py`.
 
 **Signature:**
 
 ```python
-def apply_inhomogeneous_bc(
+def apply_known_values(
     rhs: Float[Array, "Ny Nx"],
-    bc_values: Float[Array, "Ny Nx"],
+    known_values: Float[Array, "Ny Nx"],
     mask: Float[Array, "Ny Nx"] | Mask2D,
     dx: float,
     dy: float,
     lambda_: float = 0.0,
+    known_mask: Bool[Array, "Ny Nx"] | None = None,
 ) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
-    """Correct RHS for inhomogeneous Dirichlet BCs via the lifting trick.
+    """Correct RHS for known values via the generalized lifting trick.
 
     Parameters
     ----------
     rhs : (Ny, Nx) array
-        Original right-hand side (should be zero at dry cells).
-    bc_values : (Ny, Nx) array
-        Prescribed boundary values.  Only values at dry cells adjacent
-        to the wet domain are used; interior values are ignored.
+        Original right-hand side.
+    known_values : (Ny, Nx) array
+        Prescribed values.  Only cells identified as "known" (boundary
+        ring from mask topology + explicit known_mask) are used.
     mask : (Ny, Nx) array or Mask2D
         Binary wet/dry mask (1=wet, 0=dry).
     dx, dy : float
         Grid spacings.
     lambda_ : float
         Helmholtz parameter.
+    known_mask : (Ny, Nx) bool array or None
+        Explicit known-value locations (e.g., sparse observations at
+        interior wet cells).  Merged with auto-derived boundary ring.
 
     Returns
     -------
     rhs_corrected : (Ny, Nx) array
-        Corrected RHS for the homogeneous problem.
-    psi_lift : (Ny, Nx) array
-        Lifting function -- add to homogeneous solution to get full solution.
+        Corrected RHS for the reduced homogeneous problem.
+    value_lift : (Ny, Nx) array
+        Lifting function — add to homogeneous solution to get full solution.
     """
 ```
 
+**Proposed location:** `finitevolx/_src/solvers/inhomogeneous.py` (new file),
+re-exported from `finitevolx/__init__.py`.
+
 ---
 
-### Layer 2 -- `bc_values=` kwarg on Convenience Wrappers
+### Layer 2 — Convenience Wrappers: `known_values` / `known_mask` kwargs
 
-The one-line API for common cases.  Adds an optional `bc_values` parameter to
-the existing `streamfunction_from_vorticity`, `pressure_from_divergence`, and
-`pv_inversion` wrappers.
+Adds optional parameters to the existing `streamfunction_from_vorticity`,
+`pressure_from_divergence`, and `pv_inversion` wrappers.
 
 ```python
 # Current API (unchanged, homogeneous only)
 psi = fvx.streamfunction_from_vorticity(zeta, dx, dy, bc="dst")
 
-# New: pass boundary values directly
+# New: pass known values directly
 psi = fvx.streamfunction_from_vorticity(
     zeta, dx, dy,
     bc="dst",
-    bc_values=g,       # NEW kwarg
-    mask=mask,         # required when bc_values is given
+    known_values=g,           # NEW
+    known_mask=obs_mask,      # NEW, optional
+    mask=mask,
 )
 
-# Same for pressure
+# Pressure
 p = fvx.pressure_from_divergence(
     div_u, dx, dy,
     bc="dct",
-    bc_values=p_boundary,
+    known_values=p_boundary,
     mask=mask,
 )
 
-# Same for PV inversion (per-layer broadcast)
+# PV inversion (per-layer broadcast)
 psi = fvx.pv_inversion(
     pv, dx, dy,
     lambda_=lambdas,
-    bc_values=psi_boundary,
+    known_values=psi_boundary,
     mask=mask,
 )
 ```
 
-**Internal flow when `bc_values` is not None:**
+**Internal flow when `known_values` is not None:**
 
 ```
-1. Call apply_inhomogeneous_bc(rhs, bc_values, mask, dx, dy, lambda_)
-      → (rhs_corrected, psi_lift)
-2. Dispatch rhs_corrected through existing _solve_dispatch(...)
+1. apply_known_values(rhs, known_values, mask, dx, dy, lambda_, known_mask)
+      → (rhs_corrected, value_lift)
+2. _solve_dispatch(rhs_corrected, ...) on effective_solve_mask
       → psi_hom
-3. Return psi_lift + psi_hom
+3. Return value_lift + psi_hom
 ```
 
-**When `bc_values is None`:** the wrapper takes the existing fast path.
-Zero behavior change for all current call sites.
+**When `known_values is None`:** existing fast path.  Zero behavior change.
 
-**Changes to `elliptic.py`:**
+**Multi-layer PV inversion:** the lift depends on `lambda_` (via
+`masked_laplacian`), so each layer gets its own corrected RHS.  The
+implementation vmaps `apply_known_values` alongside the solve, matching
+the existing vmap pattern in `elliptic.py:437-542`.
 
-- Add `bc_values: Float[Array, "Ny Nx"] | None = None` to the signature of
-  `streamfunction_from_vorticity`, `pressure_from_divergence`, and
-  `pv_inversion`.
-- Add `bc_values` to `_solve_dispatch` (or wrap the dispatch call).
-- For `pv_inversion` with array `lambda_`: the lift must be vmapped over
-  layers the same way the solve is vmapped today (`elliptic.py:437-542`).
-  Since the lift depends on `lambda_` (the Helmholtz parameter appears in
-  `masked_laplacian`), each layer gets its own corrected RHS.
+- `known_values` shape `(Ny, Nx)` → broadcast to all layers.
+- `known_values` shape `(nl, Ny, Nx)` → per-layer known values.
 
-**Spectral path on rectangular domains:**
-
-When the user passes `bc_values` with `method="spectral"` and no mask:
-
-- Synthesise a trivial all-wet mask whose dry-boundary ring is the outer
-  ghost frame.
-- Apply the standard lifting trick.
-- Pass the corrected RHS to the spectral solver (which still uses DST/DCT
-  internally and sees a homogeneous problem).
-
-Alternatively, the spectral path could use the already-exported
-`modify_rhs_2d` from `spectraldiffx` to encode the inhomogeneous data
-directly in the transform coefficients.  Both approaches are mathematically
-equivalent; the lifting trick via `masked_laplacian` is more uniform across
-solver methods.
+**Spectral path on rectangular domains:** when the user passes
+`known_values` with `method="spectral"` and no mask, synthesise a trivial
+all-wet mask whose dry-boundary ring is the outer ghost frame.
 
 ---
 
-### Layer 3 -- Bridge to the Existing BC Vocabulary
+### Layer 3 — BCSet Passthrough (unified)
 
-Accept a `BoundaryConditionSet` of `Dirichlet1D` atoms wherever `bc_values`
-is accepted, in addition to a raw array.
+The primary user-facing API.  Pass a `BoundaryConditionSet` directly to
+any solver — the mask, known values, and face BCs are all read from it.
 
 ```python
 from finitevolx import BoundaryConditionSet, Dirichlet1D
 
-# User already writes this for time-stepping:
 bc = BoundaryConditionSet(
-    south=Dirichlet1D(face="south", value=0.0),
-    north=Dirichlet1D(face="north", value=0.1),
-    west=Dirichlet1D(face="west",  value=0.05),
-    east=Dirichlet1D(face="east",  value=0.05),
+    mask=cgrid_mask,
+    south=Dirichlet1D("south", value=0.0),
+    north=Dirichlet1D("north", value=0.1),
+    west=Dirichlet1D("west", value=0.05),
+    east=Dirichlet1D("east", value=0.05),
+    known_values=obs_field,       # optional
+    known_mask=obs_locations,     # optional
 )
 
-# Now the SAME object can drive the elliptic solve:
-psi = fvx.streamfunction_from_vorticity(
-    zeta, dx, dy,
-    bc=bc,           # replaces both the string "dst" AND bc_values
-    mask=mask,
-)
+# One object drives everything:
+state = bc(state, dx, dy)                                     # time-stepping
+psi = fvx.streamfunction_from_vorticity(zeta, dx, dy, bc=bc)  # solver
+p = fvx.pressure_from_divergence(div_u, dx, dy, bc=bc)        # solver
 ```
 
-**Internal conversion:**
+**Internal conversion when `bc` is a `BoundaryConditionSet`:**
 
-When `bc` is a `BoundaryConditionSet` (instead of a string):
+1. Extract `mask` from `bc.mask`.
+2. If the BCSet has per-face `Dirichlet1D` atoms with non-zero values,
+   expand them into a `(Ny, Nx)` array (values at the ghost ring, zero in
+   the interior).
+3. Merge with `bc.known_values` / `bc.known_mask`.
+4. Determine the BC type for the spectral dispatch:
+   - All faces `Dirichlet1D` → `"dst"`
+   - All faces `Neumann1D` → `"dct"`
+   - All faces `Periodic1D` → `"fft"`
+5. Call Layer 1 (`apply_known_values`) with the merged data.
 
-1. Extract the per-face `Dirichlet1D.value` scalars (or 1-D arrays, for
-   spatially-varying data -- see "Future Extensions" below).
-2. Build a `(Ny, Nx)` array with the Dirichlet values at the ghost ring
-   and zero in the interior.
-3. Call Layer 1 (`apply_inhomogeneous_bc`) with this array.
+**Fast-path detection:** if all Dirichlet values are zero, no `known_values`,
+and no `known_mask` → take the existing spectral fast path (no mask needed).
 
-If all four values are zero, the wrapper recognises this as homogeneous
-Dirichlet and takes the fast spectral DST path (no mask needed).
-
-**Why this matters:**
-
-Users currently maintain two separate mental models -- `Dirichlet1D(value=g)`
-for time-stepping and `bc="dst"` for elliptic solves.  Layer 3 unifies them:
-one BC object, used everywhere.
-
-**Scope:**
-
-- **In scope for Layer 3:** `BoundaryConditionSet` containing `Dirichlet1D`
-  atoms (constant value per face).
-- **Out of scope:** `Neumann1D`, `Robin1D`, and spatially-varying per-face
-  values.  These require deeper changes (e.g. integrating with
-  `MixedBCHelmholtzSolver2D` from `spectraldiffx` for the spectral path,
-  or extending `masked_laplacian` for Neumann conditions at the mask edge).
-  Flagged as future work.
+**Why this matters:** users maintain one mental model.  The same
+`BoundaryConditionSet` they write for time-stepping drives the elliptic
+solve.  No more `Dirichlet1D(value=g)` for one system and `bc="dst"` for the
+other.
 
 ---
 
-## 4. Considered Alternatives
+## 5. Considered Alternatives
 
 ### Option B from issue #186: `InhomogeneousBCSolver` wrapper class
 
 ```python
-solver = InhomogeneousBCSolver(
-    base_solver=base_solver,
-    mask=mask, dx=dx, dy=dy, lambda_=0.0,
-)
-psi = solver(rhs, bc_values=g)
+solver = InhomogeneousBCSolver(base_solver=..., mask=mask, dx=dx, dy=dy)
+psi = solver(rhs, known_values=g)
 ```
 
-**Why not:** A class adds state (base solver, mask, grid params) without
-adding power.  The layered function + kwarg design covers every code path the
-class would, with less surface area and better composability (the pure
-function in Layer 1 works with any solver without wrapping it).
+**Why not:** a class adds state without adding power.  The layered function +
+BCSet passthrough covers every code path with less surface area and better
+composability.
 
-### Option D from issue #186: `DirichletBC` / `NeumannBC` value objects
+### Option D from issue #186: new `DirichletBC` / `NeumannBC` types
 
 ```python
 bc = DirichletBC(values=g, mask=mask)
-psi = fvx.streamfunction_from_vorticity(zeta, dx, dy, bc=bc)
 ```
 
-**Why not now:** This is essentially what Layer 3 does, but it invents a
-*new* BC type (`DirichletBC`) parallel to the existing `Dirichlet1D`.  Layer 3
-reuses the existing vocabulary instead.  If the library eventually needs
-`NeumannBC` / `RobinBC` for the solver layer, these can be introduced later
-with clear integration points (the `MixedBCHelmholtzSolver2D` from
-`spectraldiffx` for the spectral path, extended `masked_laplacian` for the
-CG path).
+**Why not:** invents a new BC type parallel to the existing `Dirichlet1D`.
+The revised design evolves the existing `BoundaryConditionSet` instead of
+creating a parallel hierarchy.
 
 ---
 
-## 5. Edge Cases and Decisions
+## 6. Edge Cases and Decisions
 
 ### Spectral solvers without a mask
 
-When `method="spectral"` and no mask is provided, but `bc_values` is given:
-
-- Synthesise a rectangular mask: all-wet interior, dry boundary ring.
-  This is just `mask[1:-1, 1:-1] = 1, mask[boundary] = 0` for an `(Ny, Nx)`
-  domain.
-- Apply the lifting trick normally.
-- Document that this adds a small overhead vs. the pure spectral path
-  (one extra Laplacian evaluation for the correction).
+When `method="spectral"` and no mask is provided, but `known_values` is
+given: synthesise a rectangular mask (all-wet interior, dry outer ring).
+Apply the lifting trick normally.
 
 ### Capacitance solver
 
-The lift trick is operator-agnostic.  The capacitance solver
-(`build_capacitance_solver`, `elliptic.py:146-183`) sees only the corrected
-RHS and solves the homogeneous problem as usual.  No changes needed.
+Operator-agnostic.  The capacitance solver sees only the corrected RHS and
+solves the homogeneous problem as usual.  No changes needed.
 
 ### Multigrid
 
 Same: only the RHS changes.  The V-cycle hierarchy is unaware of the lift.
-The multigrid operator (`multigrid.py:327-410`) already enforces zero BCs via
-its face coefficients; the corrected RHS accounts for the non-zero data.
 
-### Time-varying boundary values
+### Time-varying known values
 
 Because Layer 1 is a pure function, the correction is recomputed at every
-call inside a JIT-compiled timestep.  No caching or stale-state issues.  The
-JAX-native dilation is cheap (~4 rolls + OR), and `masked_laplacian` is a
-single 5-point stencil pass.
+call inside a JIT-compiled timestep.  No caching or stale-state issues.
+
+### Sparse observations as known values
+
+When `known_mask` marks interior wet cells, those cells are removed from the
+solve domain (`effective_solve_mask = wet & ~all_known`).  Their prescribed
+values feed into the stencil of neighboring "unknown" cells via the lift.
+Mathematically, this treats observations as additional Dirichlet constraints
+in the interior of the domain.
 
 ### Multi-layer PV inversion
 
-`pv_inversion` with array `lambda_` currently vmaps the solve over layers
-(`elliptic.py:437-542`).  The lift depends on `lambda_` (via
-`masked_laplacian`), so each layer gets its own `rhs_corrected` and
-`psi_lift`.  The implementation vmaps `apply_inhomogeneous_bc` over the layer
-axis alongside the solve, or pre-computes the per-layer lifts in a batched
-call.
-
-If `bc_values` has shape `(nl, Ny, Nx)`, each layer gets its own boundary
-data.  If `bc_values` has shape `(Ny, Nx)`, it is broadcast to all layers
-(common case: same boundary data for all vertical modes).
+The lift depends on `lambda_` (via `masked_laplacian`), so each layer gets
+its own `rhs_corrected` and `value_lift`.  `known_values` can be `(Ny, Nx)`
+(broadcast) or `(nl, Ny, Nx)` (per-layer).
 
 ### Sign of lambda
 
 Preserved by the existing `masked_laplacian` definition: it computes
 $(∇^2 - \lambda)\psi$, so both the RHS and the correction have consistent
-sign.  No special-casing needed.
+sign.
 
-### Homogeneous BC special case (g = 0)
+### Homogeneous special case (all known values = 0)
 
-When `bc_values` is all zeros (or `None`), the lift is zero, the RHS
-correction is zero, and the solver takes the fast path.  The design doc does
-not need a separate code path for this -- the math handles it naturally, and
-the overhead of the zero-lift check is negligible.
+The lift is zero, the RHS correction is zero, and the solver takes the fast
+path.  No separate code branch needed.
 
 ---
 
-## 6. Phasing
+## 7. Phasing
 
-### PR 1: Layer 1 -- `apply_inhomogeneous_bc`
+### PR 1: Evolve `BoundaryConditionSet` + `apply_known_values`
 
-**Scope:**
-
+- Add `mask`, `known_values`, `known_mask` fields to `BoundaryConditionSet`
+  (all default `None` — backward compatible).
 - New file `finitevolx/_src/solvers/inhomogeneous.py` with
-  `apply_inhomogeneous_bc`.
-- JAX-native dilation helper (private function in the same module).
+  `apply_known_values` pure function + JAX-native dilation helper.
 - Re-export from `finitevolx/__init__.py`.
-- Manufactured-solution test: $\psi_{\text{exact}} = \sin(\pi x)\sin(\pi y) +
-  0.1\sin(2\pi y)$ (second term doesn't vanish at boundaries).  Compute
-  $f = (A - \lambda)\psi_{\text{exact}}$, extract $g = \psi_{\text{exact}}\big|_{\text{boundary}}$,
-  solve, verify $\|\psi - \psi_{\text{exact}}\| < \epsilon$.
-- Consistency test: homogeneous BCs ($g = 0$) give the same result as the
-  current API.
-- Test with CG, capacitance, and spectral solver methods.
+- Tests:
+  - Manufactured solution: $\psi_{\text{exact}} = \sin(\pi x)\sin(\pi y) +
+    0.1\sin(2\pi y)$ with CG, capacitance, spectral.
+  - Consistency: `known_values=0` matches current homogeneous API.
+  - Island mask: verify auto-derive finds inner + outer boundary rings.
+  - Sparse obs: verify `known_mask` pins interior cells correctly.
 
-**Estimated size:** ~60 lines of implementation, ~120 lines of tests.
+### PR 2: Thread through convenience wrappers + BCSet passthrough
 
-### PR 2: Layer 2 -- `bc_values=` kwarg
-
-**Scope:**
-
-- Add `bc_values` parameter to `streamfunction_from_vorticity`,
-  `pressure_from_divergence`, and `pv_inversion`.
-- Thread it through `_solve_dispatch`.
+- Add `known_values` / `known_mask` kwargs to
+  `streamfunction_from_vorticity`, `pressure_from_divergence`, `pv_inversion`.
+- Accept `BoundaryConditionSet` as `bc=` parameter (Layer 3).
 - Multi-layer vmap integration for `pv_inversion`.
-- Auto-synthesise rectangular mask for spectral path when no mask given.
-- Tests for all three wrappers with `bc_values`.
+- Auto-synthesise rectangular mask for spectral path.
+- Tests for all three wrappers with known values and BCSet passthrough.
 
-**Estimated size:** ~80 lines of implementation changes, ~150 lines of tests.
+### PR 3: Documentation + notebook migration
 
-### PR 3: Layer 3 -- `BoundaryConditionSet` bridge
-
-**Scope:**
-
-- Accept `BoundaryConditionSet` in `bc=` parameter.
-- Extract per-face Dirichlet values, build `(Ny, Nx)` lift array.
-- Fast-path detection for all-zero homogeneous case.
-- Update `docs/notebooks/demo_solvers.py` Section 8 to use the new API
-  instead of the manual lifting trick.
+- Update `docs/notebooks/demo_solvers.py` Section 8 to use new API.
 - Documentation in elliptic solver guide.
-
-**Estimated size:** ~60 lines of implementation, ~80 lines of tests, ~100
-lines of doc updates.
+- Update `docs/boundary_conditions.md` with unified BCSet description.
 
 ---
 
-## 7. Acceptance Criteria
+## 8. Acceptance Criteria
 
-From issue #186, with additions:
+From issue #186, revised for the broader scope:
 
-- [ ] `apply_inhomogeneous_bc(rhs, bc_values, mask, dx, dy, lambda_)` implemented
-- [ ] Convenience wrappers accept `bc_values` parameter
-- [ ] `BoundaryConditionSet` of `Dirichlet1D` accepted as `bc=` on wrappers
+- [ ] `BoundaryConditionSet` gains `mask`, `known_values`, `known_mask` fields
+- [ ] `apply_known_values(rhs, known_values, mask, dx, dy, lambda_, known_mask)` implemented
+- [ ] Convenience wrappers accept `known_values` / `known_mask` parameters
+- [ ] `BoundaryConditionSet` accepted as `bc=` on all convenience wrappers
 - [ ] Works with all solver methods (spectral, CG, capacitance, multigrid)
 - [ ] Manufactured-solution test passes to solver tolerance
+- [ ] Island-mask test: auto-derive finds inner + outer boundary rings
+- [ ] Sparse-obs test: `known_mask` pins interior wet cells correctly
 - [ ] JIT-compatible for time-stepping applications
-- [ ] Multi-layer `pv_inversion` supports per-layer `bc_values`
+- [ ] Multi-layer `pv_inversion` supports per-layer `known_values`
+- [ ] JAX-native dilation (no SciPy dependency in the hot path)
 - [ ] Documentation in elliptic solver guide
 - [ ] Example in `demo_solvers` notebook updated to use new API
-- [ ] JAX-native dilation (no SciPy dependency in the hot path)
 
 ---
 
-## 8. Future Extensions (Out of Scope)
-
-These are explicitly **not** part of the initial implementation but have clear
-integration points:
+## 9. Future Extensions (Out of Scope)
 
 | Extension | Integration point |
 |-----------|-------------------|
-| **Spatially-varying per-face Dirichlet values** (1-D arrays instead of scalars on `Dirichlet1D`) | Layer 3 conversion: expand 1-D face arrays into `(Ny, Nx)` lift |
-| **Inhomogeneous Neumann** ($\partial\psi/\partial n = g$) | `modify_rhs_2d` from spectraldiffx (spectral path); extended `masked_laplacian` with ghost-cell injection (CG path) |
-| **Robin / mixed BCs on the solver** | `MixedBCHelmholtzSolver2D` from spectraldiffx (`spectral.py:19`); new Robin-aware operator for CG |
-| **Open-boundary conditions** (radiation, sponge) | Sponge1D / Robin1D already exist for time-stepping; solver integration requires absorbing-layer operator modifications |
-| **3-D support** | All existing spectral solvers have 3-D variants (`solve_helmholtz_dst1_3d`, etc.); the lifting trick generalises to 3-D with a 6-point dilation |
+| **Spatially-varying per-face Dirichlet** (1-D arrays on `Dirichlet1D`) | Layer 3 conversion: expand 1-D face arrays into `(Ny, Nx)` lift |
+| **Inhomogeneous Neumann** ($\partial\psi/\partial n = g$) | `modify_rhs_2d` from spectraldiffx (spectral path); extended `masked_laplacian` (CG path) |
+| **Robin / mixed BCs on the solver** | `MixedBCHelmholtzSolver2D` from spectraldiffx; new Robin-aware operator for CG |
+| **Open-boundary conditions** (radiation, sponge) | Sponge1D / Robin1D already exist for time-stepping; solver integration requires absorbing-layer operator |
+| **3-D support** | Lifting trick generalises to 3-D with a 6-point dilation; all spectral solvers have 3-D variants |
+| **Weighted observations** (soft constraints) | Penalty-method variant of the lifting trick: add `weight * (psi - obs)` to the operator instead of hard pinning |
 
 ---
 

--- a/docs/design/research/boundaries/inhomogeneous_bcs_design.md
+++ b/docs/design/research/boundaries/inhomogeneous_bcs_design.md
@@ -1,0 +1,460 @@
+# Inhomogeneous Boundary Conditions in finitevolX: Future API Design
+
+This document proposes a layered API for **inhomogeneous (non-zero) Dirichlet
+boundary conditions** on finitevolX's elliptic solvers, responding to
+[jejjohnson/finitevolX#186](https://github.com/jejjohnson/finitevolX/issues/186).
+
+**Companion document:** [inhomogeneous_bcs_current.md](./inhomogeneous_bcs_current.md)
+describes the current state and the manual lifting trick.
+
+---
+
+## 1. Goal
+
+Support solving $(A - \lambda)\psi = f$ with $\psi = g$ on the boundary
+($g \neq 0$), where:
+
+- The solution is **JIT-compilable** and **vmap-compatible** (including
+  time-varying $g$).
+- It **composes with all four solver methods**: spectral, CG, capacitance,
+  and multigrid.
+- It causes **zero behavior change** for existing call sites that don't pass
+  boundary data.
+- It **bridges** the existing `Dirichlet1D` / `BoundaryConditionSet`
+  vocabulary from the time-stepping BC layer to the elliptic solver layer.
+
+---
+
+## 2. Design Principles
+
+1. **Reuse, don't reinvent.**  The `Dirichlet1D`, `BoundaryConditionSet`, and
+   `masked_laplacian` APIs already exist.  The new code should call them,
+   not duplicate their logic.
+
+2. **The lifting trick is the implementation, not the API.**  Users should
+   never write `binary_dilation` or manually compute the corrected RHS.
+   That logic is encapsulated behind a single entry point.
+
+3. **JAX-native throughout.**  Replace the SciPy `binary_dilation` from the
+   demo notebook with a JAX-native one-cell dilation (XOR of mask shifts),
+   so the entire path is JIT-friendly without a NumPy round-trip.
+
+4. **One implementation, three layers of API.**  The lifting logic is written
+   once (Layer 1, a pure function).  Layers 2 and 3 are thin wrappers that
+   call Layer 1.
+
+5. **Additive, not breaking.**  All new parameters have default `None`, so
+   existing call sites remain unchanged.
+
+---
+
+## 3. Recommended Design: Three Layers
+
+### Layer 1 -- Pure Function: `apply_inhomogeneous_bc`
+
+The foundation.  A composable pure function that performs the lifting trick
+and returns the corrected RHS + lift array.
+
+```python
+from finitevolx import apply_inhomogeneous_bc
+
+rhs_corrected, psi_lift = apply_inhomogeneous_bc(
+    rhs=rhs,
+    bc_values=g,          # (Ny, Nx) array; only dry-boundary values matter
+    mask=mask,            # (Ny, Nx) binary mask (1=wet, 0=dry)
+    dx=dx, dy=dy,
+    lambda_=0.0,
+)
+
+# Solve with ANY solver (spectral, CG, capacitance, multigrid)
+psi_hom = my_solver(rhs_corrected)
+
+# Reconstruct
+psi = psi_lift + psi_hom
+```
+
+**What it does internally:**
+
+```
+1. Compute dry boundary ring (JAX-native dilation):
+   wet = mask > 0.5
+   dilated = wet | roll(wet, +1, axis=0) | roll(wet, -1, axis=0)
+                  | roll(wet, +1, axis=1) | roll(wet, -1, axis=1)
+   dry_boundary = dilated & ~wet
+
+2. Build lift:
+   psi_lift = jnp.where(dry_boundary, bc_values, 0.0)
+
+3. Correct RHS:
+   A_lift = masked_laplacian(psi_lift, mask, dx, dy, lambda_)
+   rhs_corrected = rhs - A_lift
+
+4. Return (rhs_corrected, psi_lift)
+```
+
+**Key design choices:**
+
+- Returns **both** `rhs_corrected` and `psi_lift` so the caller can
+  reconstruct the full solution.  Returning only the corrected RHS would
+  force users to recompute the lift to add it back.
+- Accepts a full `(Ny, Nx)` array for `bc_values`, not just boundary
+  slices.  Interior values are ignored (masked out by `dry_boundary`).
+  This is simpler and more flexible -- users can pass a full reanalysis
+  field without extracting boundary cells.
+- Uses `masked_laplacian` (`iterative.py:144-191`) for the
+  $A\psi_{\text{lift}}$ step.  No new operator.
+- The JAX-native dilation replaces `scipy.ndimage.binary_dilation`, making
+  the function JIT-compilable.  The mask is static (shape doesn't change),
+  so the dilation is cheap.
+
+**Proposed location:** `finitevolx/_src/solvers/inhomogeneous.py` (new file),
+re-exported from `finitevolx/_src/solvers/elliptic.py` and
+`finitevolx/__init__.py`.
+
+**Signature:**
+
+```python
+def apply_inhomogeneous_bc(
+    rhs: Float[Array, "Ny Nx"],
+    bc_values: Float[Array, "Ny Nx"],
+    mask: Float[Array, "Ny Nx"] | Mask2D,
+    dx: float,
+    dy: float,
+    lambda_: float = 0.0,
+) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
+    """Correct RHS for inhomogeneous Dirichlet BCs via the lifting trick.
+
+    Parameters
+    ----------
+    rhs : (Ny, Nx) array
+        Original right-hand side (should be zero at dry cells).
+    bc_values : (Ny, Nx) array
+        Prescribed boundary values.  Only values at dry cells adjacent
+        to the wet domain are used; interior values are ignored.
+    mask : (Ny, Nx) array or Mask2D
+        Binary wet/dry mask (1=wet, 0=dry).
+    dx, dy : float
+        Grid spacings.
+    lambda_ : float
+        Helmholtz parameter.
+
+    Returns
+    -------
+    rhs_corrected : (Ny, Nx) array
+        Corrected RHS for the homogeneous problem.
+    psi_lift : (Ny, Nx) array
+        Lifting function -- add to homogeneous solution to get full solution.
+    """
+```
+
+---
+
+### Layer 2 -- `bc_values=` kwarg on Convenience Wrappers
+
+The one-line API for common cases.  Adds an optional `bc_values` parameter to
+the existing `streamfunction_from_vorticity`, `pressure_from_divergence`, and
+`pv_inversion` wrappers.
+
+```python
+# Current API (unchanged, homogeneous only)
+psi = fvx.streamfunction_from_vorticity(zeta, dx, dy, bc="dst")
+
+# New: pass boundary values directly
+psi = fvx.streamfunction_from_vorticity(
+    zeta, dx, dy,
+    bc="dst",
+    bc_values=g,       # NEW kwarg
+    mask=mask,         # required when bc_values is given
+)
+
+# Same for pressure
+p = fvx.pressure_from_divergence(
+    div_u, dx, dy,
+    bc="dct",
+    bc_values=p_boundary,
+    mask=mask,
+)
+
+# Same for PV inversion (per-layer broadcast)
+psi = fvx.pv_inversion(
+    pv, dx, dy,
+    lambda_=lambdas,
+    bc_values=psi_boundary,
+    mask=mask,
+)
+```
+
+**Internal flow when `bc_values` is not None:**
+
+```
+1. Call apply_inhomogeneous_bc(rhs, bc_values, mask, dx, dy, lambda_)
+      → (rhs_corrected, psi_lift)
+2. Dispatch rhs_corrected through existing _solve_dispatch(...)
+      → psi_hom
+3. Return psi_lift + psi_hom
+```
+
+**When `bc_values is None`:** the wrapper takes the existing fast path.
+Zero behavior change for all current call sites.
+
+**Changes to `elliptic.py`:**
+
+- Add `bc_values: Float[Array, "Ny Nx"] | None = None` to the signature of
+  `streamfunction_from_vorticity`, `pressure_from_divergence`, and
+  `pv_inversion`.
+- Add `bc_values` to `_solve_dispatch` (or wrap the dispatch call).
+- For `pv_inversion` with array `lambda_`: the lift must be vmapped over
+  layers the same way the solve is vmapped today (`elliptic.py:437-542`).
+  Since the lift depends on `lambda_` (the Helmholtz parameter appears in
+  `masked_laplacian`), each layer gets its own corrected RHS.
+
+**Spectral path on rectangular domains:**
+
+When the user passes `bc_values` with `method="spectral"` and no mask:
+
+- Synthesise a trivial all-wet mask whose dry-boundary ring is the outer
+  ghost frame.
+- Apply the standard lifting trick.
+- Pass the corrected RHS to the spectral solver (which still uses DST/DCT
+  internally and sees a homogeneous problem).
+
+Alternatively, the spectral path could use the already-exported
+`modify_rhs_2d` from `spectraldiffx` to encode the inhomogeneous data
+directly in the transform coefficients.  Both approaches are mathematically
+equivalent; the lifting trick via `masked_laplacian` is more uniform across
+solver methods.
+
+---
+
+### Layer 3 -- Bridge to the Existing BC Vocabulary
+
+Accept a `BoundaryConditionSet` of `Dirichlet1D` atoms wherever `bc_values`
+is accepted, in addition to a raw array.
+
+```python
+from finitevolx import BoundaryConditionSet, Dirichlet1D
+
+# User already writes this for time-stepping:
+bc = BoundaryConditionSet(
+    south=Dirichlet1D(face="south", value=0.0),
+    north=Dirichlet1D(face="north", value=0.1),
+    west=Dirichlet1D(face="west",  value=0.05),
+    east=Dirichlet1D(face="east",  value=0.05),
+)
+
+# Now the SAME object can drive the elliptic solve:
+psi = fvx.streamfunction_from_vorticity(
+    zeta, dx, dy,
+    bc=bc,           # replaces both the string "dst" AND bc_values
+    mask=mask,
+)
+```
+
+**Internal conversion:**
+
+When `bc` is a `BoundaryConditionSet` (instead of a string):
+
+1. Extract the per-face `Dirichlet1D.value` scalars (or 1-D arrays, for
+   spatially-varying data -- see "Future Extensions" below).
+2. Build a `(Ny, Nx)` array with the Dirichlet values at the ghost ring
+   and zero in the interior.
+3. Call Layer 1 (`apply_inhomogeneous_bc`) with this array.
+
+If all four values are zero, the wrapper recognises this as homogeneous
+Dirichlet and takes the fast spectral DST path (no mask needed).
+
+**Why this matters:**
+
+Users currently maintain two separate mental models -- `Dirichlet1D(value=g)`
+for time-stepping and `bc="dst"` for elliptic solves.  Layer 3 unifies them:
+one BC object, used everywhere.
+
+**Scope:**
+
+- **In scope for Layer 3:** `BoundaryConditionSet` containing `Dirichlet1D`
+  atoms (constant value per face).
+- **Out of scope:** `Neumann1D`, `Robin1D`, and spatially-varying per-face
+  values.  These require deeper changes (e.g. integrating with
+  `MixedBCHelmholtzSolver2D` from `spectraldiffx` for the spectral path,
+  or extending `masked_laplacian` for Neumann conditions at the mask edge).
+  Flagged as future work.
+
+---
+
+## 4. Considered Alternatives
+
+### Option B from issue #186: `InhomogeneousBCSolver` wrapper class
+
+```python
+solver = InhomogeneousBCSolver(
+    base_solver=base_solver,
+    mask=mask, dx=dx, dy=dy, lambda_=0.0,
+)
+psi = solver(rhs, bc_values=g)
+```
+
+**Why not:** A class adds state (base solver, mask, grid params) without
+adding power.  The layered function + kwarg design covers every code path the
+class would, with less surface area and better composability (the pure
+function in Layer 1 works with any solver without wrapping it).
+
+### Option D from issue #186: `DirichletBC` / `NeumannBC` value objects
+
+```python
+bc = DirichletBC(values=g, mask=mask)
+psi = fvx.streamfunction_from_vorticity(zeta, dx, dy, bc=bc)
+```
+
+**Why not now:** This is essentially what Layer 3 does, but it invents a
+*new* BC type (`DirichletBC`) parallel to the existing `Dirichlet1D`.  Layer 3
+reuses the existing vocabulary instead.  If the library eventually needs
+`NeumannBC` / `RobinBC` for the solver layer, these can be introduced later
+with clear integration points (the `MixedBCHelmholtzSolver2D` from
+`spectraldiffx` for the spectral path, extended `masked_laplacian` for the
+CG path).
+
+---
+
+## 5. Edge Cases and Decisions
+
+### Spectral solvers without a mask
+
+When `method="spectral"` and no mask is provided, but `bc_values` is given:
+
+- Synthesise a rectangular mask: all-wet interior, dry boundary ring.
+  This is just `mask[1:-1, 1:-1] = 1, mask[boundary] = 0` for an `(Ny, Nx)`
+  domain.
+- Apply the lifting trick normally.
+- Document that this adds a small overhead vs. the pure spectral path
+  (one extra Laplacian evaluation for the correction).
+
+### Capacitance solver
+
+The lift trick is operator-agnostic.  The capacitance solver
+(`build_capacitance_solver`, `elliptic.py:146-183`) sees only the corrected
+RHS and solves the homogeneous problem as usual.  No changes needed.
+
+### Multigrid
+
+Same: only the RHS changes.  The V-cycle hierarchy is unaware of the lift.
+The multigrid operator (`multigrid.py:327-410`) already enforces zero BCs via
+its face coefficients; the corrected RHS accounts for the non-zero data.
+
+### Time-varying boundary values
+
+Because Layer 1 is a pure function, the correction is recomputed at every
+call inside a JIT-compiled timestep.  No caching or stale-state issues.  The
+JAX-native dilation is cheap (~4 rolls + OR), and `masked_laplacian` is a
+single 5-point stencil pass.
+
+### Multi-layer PV inversion
+
+`pv_inversion` with array `lambda_` currently vmaps the solve over layers
+(`elliptic.py:437-542`).  The lift depends on `lambda_` (via
+`masked_laplacian`), so each layer gets its own `rhs_corrected` and
+`psi_lift`.  The implementation vmaps `apply_inhomogeneous_bc` over the layer
+axis alongside the solve, or pre-computes the per-layer lifts in a batched
+call.
+
+If `bc_values` has shape `(nl, Ny, Nx)`, each layer gets its own boundary
+data.  If `bc_values` has shape `(Ny, Nx)`, it is broadcast to all layers
+(common case: same boundary data for all vertical modes).
+
+### Sign of lambda
+
+Preserved by the existing `masked_laplacian` definition: it computes
+$(∇^2 - \lambda)\psi$, so both the RHS and the correction have consistent
+sign.  No special-casing needed.
+
+### Homogeneous BC special case (g = 0)
+
+When `bc_values` is all zeros (or `None`), the lift is zero, the RHS
+correction is zero, and the solver takes the fast path.  The design doc does
+not need a separate code path for this -- the math handles it naturally, and
+the overhead of the zero-lift check is negligible.
+
+---
+
+## 6. Phasing
+
+### PR 1: Layer 1 -- `apply_inhomogeneous_bc`
+
+**Scope:**
+
+- New file `finitevolx/_src/solvers/inhomogeneous.py` with
+  `apply_inhomogeneous_bc`.
+- JAX-native dilation helper (private function in the same module).
+- Re-export from `finitevolx/__init__.py`.
+- Manufactured-solution test: $\psi_{\text{exact}} = \sin(\pi x)\sin(\pi y) +
+  0.1\sin(2\pi y)$ (second term doesn't vanish at boundaries).  Compute
+  $f = (A - \lambda)\psi_{\text{exact}}$, extract $g = \psi_{\text{exact}}\big|_{\text{boundary}}$,
+  solve, verify $\|\psi - \psi_{\text{exact}}\| < \epsilon$.
+- Consistency test: homogeneous BCs ($g = 0$) give the same result as the
+  current API.
+- Test with CG, capacitance, and spectral solver methods.
+
+**Estimated size:** ~60 lines of implementation, ~120 lines of tests.
+
+### PR 2: Layer 2 -- `bc_values=` kwarg
+
+**Scope:**
+
+- Add `bc_values` parameter to `streamfunction_from_vorticity`,
+  `pressure_from_divergence`, and `pv_inversion`.
+- Thread it through `_solve_dispatch`.
+- Multi-layer vmap integration for `pv_inversion`.
+- Auto-synthesise rectangular mask for spectral path when no mask given.
+- Tests for all three wrappers with `bc_values`.
+
+**Estimated size:** ~80 lines of implementation changes, ~150 lines of tests.
+
+### PR 3: Layer 3 -- `BoundaryConditionSet` bridge
+
+**Scope:**
+
+- Accept `BoundaryConditionSet` in `bc=` parameter.
+- Extract per-face Dirichlet values, build `(Ny, Nx)` lift array.
+- Fast-path detection for all-zero homogeneous case.
+- Update `docs/notebooks/demo_solvers.py` Section 8 to use the new API
+  instead of the manual lifting trick.
+- Documentation in elliptic solver guide.
+
+**Estimated size:** ~60 lines of implementation, ~80 lines of tests, ~100
+lines of doc updates.
+
+---
+
+## 7. Acceptance Criteria
+
+From issue #186, with additions:
+
+- [ ] `apply_inhomogeneous_bc(rhs, bc_values, mask, dx, dy, lambda_)` implemented
+- [ ] Convenience wrappers accept `bc_values` parameter
+- [ ] `BoundaryConditionSet` of `Dirichlet1D` accepted as `bc=` on wrappers
+- [ ] Works with all solver methods (spectral, CG, capacitance, multigrid)
+- [ ] Manufactured-solution test passes to solver tolerance
+- [ ] JIT-compatible for time-stepping applications
+- [ ] Multi-layer `pv_inversion` supports per-layer `bc_values`
+- [ ] Documentation in elliptic solver guide
+- [ ] Example in `demo_solvers` notebook updated to use new API
+- [ ] JAX-native dilation (no SciPy dependency in the hot path)
+
+---
+
+## 8. Future Extensions (Out of Scope)
+
+These are explicitly **not** part of the initial implementation but have clear
+integration points:
+
+| Extension | Integration point |
+|-----------|-------------------|
+| **Spatially-varying per-face Dirichlet values** (1-D arrays instead of scalars on `Dirichlet1D`) | Layer 3 conversion: expand 1-D face arrays into `(Ny, Nx)` lift |
+| **Inhomogeneous Neumann** ($\partial\psi/\partial n = g$) | `modify_rhs_2d` from spectraldiffx (spectral path); extended `masked_laplacian` with ghost-cell injection (CG path) |
+| **Robin / mixed BCs on the solver** | `MixedBCHelmholtzSolver2D` from spectraldiffx (`spectral.py:19`); new Robin-aware operator for CG |
+| **Open-boundary conditions** (radiation, sponge) | Sponge1D / Robin1D already exist for time-stepping; solver integration requires absorbing-layer operator modifications |
+| **3-D support** | All existing spectral solvers have 3-D variants (`solve_helmholtz_dst1_3d`, etc.); the lifting trick generalises to 3-D with a 6-point dilation |
+
+---
+
+*See [inhomogeneous_bcs_current.md](./inhomogeneous_bcs_current.md) for the
+current state and the manual lifting trick this design replaces.*

--- a/docs/design/research/boundaries/inhomogeneous_bcs_design.md
+++ b/docs/design/research/boundaries/inhomogeneous_bcs_design.md
@@ -95,8 +95,8 @@ The set of "known cells" is computed by combining two sources:
 
 ```
 # 1. Auto-derive boundary cells from mask topology
-#    (outer boundary ring + island coast rings)
-boundary_cells = _dilate(wet_mask) & ~wet_mask
+#    (inner ring: wet cells adjacent to at least one dry cell)
+boundary_cells = boundary_ring(mask)  # wet & adjacent_to_dry
 
 # 2. Merge with explicit known_mask (sparse obs, etc.)
 if known_mask is not None:
@@ -215,32 +215,31 @@ lifting trick.  Accepts all parameters explicitly (maximum composability for
 power users who want to bring their own solver).
 
 ```python
-from finitevolx import apply_known_values
+from finitevolx import SolveDomain, KnownValueLifting
 
-rhs_corrected, value_lift = apply_known_values(
-    rhs=rhs,
-    known_values=obs_field,     # (Ny, Nx) prescribed values
-    mask=mask,                  # (Ny, Nx) wet/dry mask
-    dx=dx, dy=dy,
-    lambda_=0.0,
-    known_mask=obs_locations,   # optional: explicit obs cells
-)
+# Setup (once)
+domain = SolveDomain(mask=mask, known_mask=obs_locations)
+lifter = KnownValueLifting(domain=domain, dx=dx, dy=dy, lambda_=0.0)
 
-# Solve with ANY solver
+# Per step
+rhs_corrected, value_lift = lifter.preprocess(rhs, obs_field)
+
+# Solve with ANY solver (built with domain.effective_mask)
 psi_hom = my_solver(rhs_corrected)
 
 # Reconstruct
-psi = value_lift + psi_hom
+psi = lifter.postprocess(psi_hom, value_lift)
 ```
 
 **What it does internally:**
 
 ```
-1. Auto-derive boundary ring from mask (JAX-native dilation):
+1. Auto-derive boundary ring from mask (pad-then-slice):
    wet = mask > 0.5
-   dilated = wet | roll(wet, +1, 0) | roll(wet, -1, 0)
-                  | roll(wet, +1, 1) | roll(wet, -1, 1)
-   boundary_cells = dilated & ~wet
+   dry = ~wet
+   padded_dry = pad(dry, 1, constant=False)
+   adjacent_to_dry = padded_dry[2:,1:-1] | padded_dry[:-2,1:-1] | ...
+   boundary_cells = wet & adjacent_to_dry
 
 2. Merge with explicit known_mask:
    all_known = boundary_cells | known_mask   (if known_mask given)

--- a/docs/design/research/boundaries/plan.md
+++ b/docs/design/research/boundaries/plan.md
@@ -1,0 +1,212 @@
+Context
+The original design doc (committed on claude/inhomogeneous-bcs-design-r3fte)
+proposed a 3-layer API narrowly scoped to inhomogeneous Dirichlet BCs.
+After user review, the scope has expanded based on four critiques:
+
+Broader BC scope — design a unified BC/BCSet that works for
+time-stepping, solvers, and direct state application (not just solver-side
+inhomogeneous Dirichlet).
+BCSet owns the mask — the BoundaryConditionSet should carry a
+Mask2D, so solvers can read the mask from the BC object.
+Solver operators accept the mask/BC; functionals don't — class-based
+solver operators hold the mask; functional convenience wrappers
+(streamfunction_from_vorticity) extract it from the BCSet.
+known_values, not bc_values — generalize from "boundary values" to
+"known values" at any cell: outer boundary, island coasts (auto-derived
+from mask topology), AND sparse interior observations (explicit
+known_mask). Auto-derive + merge approach.
+
+Deliverables
+Rewrite docs/design/research/boundaries/inhomogeneous_bcs_design.md on the
+same branch. The current-state doc stays mostly unchanged (minor terminology
+updates). Commit + push. Then create PR.
+
+Revised Design Doc Outline
+Section 1: Goal (expanded)
+A unified boundary condition system for finitevolX that:
+
+Works for time-stepping (ghost-cell updates), direct state application,
+and elliptic solvers
+Carries domain geometry (Mask2D) so solvers don't need a separate mask arg
+Supports known values at any cell — outer boundaries, island coasts,
+and sparse interior observations
+Is JIT-compilable, vmap-compatible, and causes zero breakage for existing
+call sites
+
+Section 2: Unified BC and BCSet Design (NEW — top of doc)
+This is the biggest change. Start the design doc with the proposed BC
+class hierarchy before getting into the solver integration.
+2.1 BC Atoms (evolve existing bc_1d.py)
+Keep the existing 9 atom types (Dirichlet1D, Neumann1D, etc.) with their
+current interface. No mask on individual atoms — they remain face-level
+building blocks.
+2.2 BoundaryConditionSet (evolve existing bc_set.py)
+Add two new fields to the existing BoundaryConditionSet:
+pythonclass BoundaryConditionSet(eqx.Module):
+    # --- Existing fields (unchanged) ---
+    south: BoundaryCondition1D | None = None
+    north: BoundaryCondition1D | None = None
+    west: BoundaryCondition1D | None = None
+    east: BoundaryCondition1D | None = None
+
+    # --- NEW fields ---
+    mask: Mask2D | Float[Array, "Ny Nx"] | None = None
+    known_values: Float[Array, "Ny Nx"] | None = None
+    known_mask: Bool[Array, "Ny Nx"] | None = None  # explicit obs locations
+Mask ownership:
+
+BCSet owns a Mask2D (or raw float array).
+Each atom extracts the right staggering when it runs (h/u/v/q from Mask2D).
+Solvers read the mask from the BCSet — user doesn't pass it separately.
+mask=None for simple rectangular domains (backward compatible).
+
+Known values:
+
+known_values: (Ny, Nx) array of prescribed values. Only cells marked
+as "known" are used; interior values at non-known cells are ignored.
+known_mask: (Ny, Nx) boolean marking explicit known-value locations
+(e.g., sparse observations at interior wet cells).
+Both are optional. When absent, behavior is identical to today.
+
+Auto-derive + merge for boundary cells:
+boundary_cells = auto_derive_from_mask(mask)   # outer ring + island coasts
+if known_mask is not None:
+    all_known = boundary_cells | known_mask     # merge in obs
+else:
+    all_known = boundary_cells
+Three scenarios this covers:
+Scenario 1: Simple basin        Scenario 2: Basin + island     Scenario 3: + observations
+0 0 0 0 0 0 0 0                 0 0 0 0 0 0 0 0                0 0 0 0 0 0 0 0
+0 . . . . . . 0                 0 . . . . . . 0                0 . . . . . . 0
+0 . . . . . . 0                 0 . . 0 0 . . 0                0 . . . . . . 0
+0 . . . . . . 0                 0 . . 0 0 . . 0                0 . X . . X . 0
+0 . . . . . . 0                 0 . . . . . . 0                0 . . . . . . 0
+0 0 0 0 0 0 0 0                 0 0 0 0 0 0 0 0                0 . . . X . . 0
+                                                                0 0 0 0 0 0 0 0
+known_mask: not needed          known_mask: not needed          known_mask: marks X cells
+Auto-derive handles it          Auto-derive handles islands     Auto + merge with explicit
+Unified interface:
+pythonbc = BoundaryConditionSet(
+    mask=cgrid_mask,
+    south=Dirichlet1D("south", value=0.0),
+    north=Dirichlet1D("north", value=0.1),
+    west=Neumann1D("west", value=0.0),
+    east=Dirichlet1D("east", value=0.05),
+    known_values=obs_field,       # optional
+    known_mask=obs_locations,     # optional
+)
+
+# Works everywhere:
+state = bc(state, dx, dy)                                    # time-stepping
+psi = fvx.streamfunction_from_vorticity(zeta, dx, dy, bc=bc) # solver
+2.3 FieldBCSet (minimal change)
+No structural change — it dispatches per-field BCSet as before. Each BCSet
+in the map can now carry its own mask + known values.
+Section 3: Design Principles (updated)
+
+Unified vocabulary — one BC object for time-stepping and solvers.
+BCSet owns the mask — solvers extract it; users don't pass it twice.
+known_values generalizes boundary data — outer rim, islands, and
+sparse obs all go through the same mechanism.
+Auto-derive + merge — boundary cells from mask topology; merge with
+explicit known_mask for interior constraints.
+Lifting trick is the implementation — users never write
+binary_dilation; the generalized lift handles all known cells.
+JAX-native — no SciPy in the hot path.
+Additive, not breaking — new fields default to None.
+
+Section 4: Solver Integration (3 layers, revised)
+Layer 1 — Pure function: apply_known_values
+Renamed from apply_inhomogeneous_bc. Accepts mask + known_values +
+known_mask explicitly (maximum composability for power users).
+pythonrhs_corrected, value_lift = apply_known_values(
+    rhs=rhs,
+    known_values=known_field,
+    mask=mask,
+    dx=dx, dy=dy,
+    lambda_=0.0,
+    known_mask=obs_mask,  # optional; auto-derives boundary ring if None
+)
+psi_hom = my_solver(rhs_corrected)
+psi = value_lift + psi_hom
+Internally:
+
+Auto-derive boundary ring from mask (JAX-native dilation)
+Merge with explicit known_mask if provided
+Build lift: value_lift = where(all_known, known_values, 0.0)
+Compute effective_solve_mask = wet_mask & ~all_known
+Correct RHS: rhs' = rhs - masked_laplacian(value_lift, effective_solve_mask, ...)
+Return (rhs_corrected, value_lift)
+
+Layer 2 — Convenience wrappers accept known_values / known_mask
+pythonpsi = fvx.streamfunction_from_vorticity(
+    zeta, dx, dy,
+    bc="dst",
+    known_values=g,        # NEW
+    known_mask=obs_mask,   # NEW, optional
+    mask=mask,
+)
+When known_values is None → existing fast path. When given → calls
+apply_known_values internally.
+Layer 3 — BCSet passthrough (unified)
+pythonbc = BoundaryConditionSet(
+    mask=mask,
+    south=Dirichlet1D("south", value=0.0),
+    known_values=obs_field,
+    known_mask=obs_locations,
+)
+
+# Solver reads mask, known_values, known_mask from bc
+psi = fvx.streamfunction_from_vorticity(zeta, dx, dy, bc=bc)
+When bc is a BoundaryConditionSet (not a string):
+
+Extract mask from bc.mask
+If bc has per-face Dirichlet atoms, expand to (Ny, Nx) boundary values
+Merge with bc.known_values / bc.known_mask
+Call Layer 1
+
+If all values are zero and no known_mask → fast spectral path.
+Section 5: Considered Alternatives (brief)
+
+Option B (wrapper class): adds state without power
+Option D (new DirichletBC type): reinvents existing vocabulary
+
+Section 6: Edge Cases
+
+Spectral without mask: synthesise rectangular mask
+Capacitance / multigrid: only RHS changes, solver unaware
+Time-varying known_values: recomputed each step (pure function)
+Multi-layer PV: vmap over layers
+Sparse obs: effective_solve_mask shrinks to exclude obs cells
+
+Section 7: Phasing
+
+PR 1: Evolve BoundaryConditionSet (add mask, known_values, known_mask)
+
+apply_known_values pure function + tests
+
+
+PR 2: Thread through convenience wrappers (known_values/known_mask kwargs
+
+BCSet passthrough)
+
+
+PR 3: Update demo_solvers notebook + docs
+
+Section 8: Acceptance Criteria
+(Updated from issue #186 + new requirements)
+Section 9: Future Extensions
+
+Spatially-varying per-face Dirichlet
+Inhomogeneous Neumann / Robin on solver
+3-D support
+
+
+Files to modify
+FileChangedocs/design/research/boundaries/inhomogeneous_bcs_design.mdFull rewrite with revised designdocs/design/research/boundaries/inhomogeneous_bcs_current.mdMinor: rename bc_values → known_values in Section 7 table
+Verification
+
+All code snippets reference real existing file:line locations
+API names consistent across all three layers
+Backward compatibility: existing call sites unchanged when new fields = None
+Cross-links between the two docs maintained

--- a/docs/design/research/boundaries/plan.md
+++ b/docs/design/research/boundaries/plan.md
@@ -41,7 +41,7 @@ Keep the existing 9 atom types (Dirichlet1D, Neumann1D, etc.) with their
 current interface. No mask on individual atoms — they remain face-level
 building blocks.
 2.2 BoundaryConditionSet (evolve existing bc_set.py)
-Add two new fields to the existing BoundaryConditionSet:
+Add three new fields to the existing BoundaryConditionSet:
 pythonclass BoundaryConditionSet(eqx.Module):
     # --- Existing fields (unchanged) ---
     south: BoundaryCondition1D | None = None

--- a/finitevolx/__init__.py
+++ b/finitevolx/__init__.py
@@ -272,6 +272,11 @@ from finitevolx._src.solvers.elliptic import (
     solve_poisson_fft_3d,
     streamfunction_from_vorticity,
 )
+from finitevolx._src.solvers.inhomogeneous import (
+    KnownValueLifting,
+    SolveDomain,
+    boundary_ring,
+)
 from finitevolx._src.solvers.multigrid import (
     MultigridSolver,
     build_multigrid_solver,
@@ -624,6 +629,10 @@ __all__ = [
     "streamfunction_from_vorticity",
     "pressure_from_divergence",
     "pv_inversion",
+    # Known-value lifting (inhomogeneous BCs)
+    "boundary_ring",
+    "SolveDomain",
+    "KnownValueLifting",
     # Multigrid Helmholtz solver
     "MultigridSolver",
     "build_multigrid_solver",

--- a/finitevolx/_src/boundary/bc_set.py
+++ b/finitevolx/_src/boundary/bc_set.py
@@ -11,6 +11,7 @@ from finitevolx._src.boundary.bc_1d import (
     Outflow1D,
     Periodic1D,
 )
+from finitevolx._src.mask import Mask2D
 
 
 class BoundaryConditionSet(eqx.Module):
@@ -38,7 +39,7 @@ class BoundaryConditionSet(eqx.Module):
     north: BoundaryCondition1D | None = None
     west: BoundaryCondition1D | None = None
     east: BoundaryCondition1D | None = None
-    mask: object = None
+    mask: Mask2D | Float[Array, "Ny Nx"] | None = None
 
     @classmethod
     def periodic(cls) -> BoundaryConditionSet:
@@ -51,7 +52,7 @@ class BoundaryConditionSet(eqx.Module):
         )
 
     @classmethod
-    def closed(cls, mask: object = None) -> BoundaryConditionSet:
+    def closed(cls, mask: Mask2D | Float[Array, "Ny Nx"] | None = None) -> BoundaryConditionSet:
         """Return a zero-Dirichlet boundary-condition set on all faces."""
         return cls(
             south=Dirichlet1D("south", value=0.0),

--- a/finitevolx/_src/boundary/bc_set.py
+++ b/finitevolx/_src/boundary/bc_set.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import equinox as eqx
 from jaxtyping import Array, Float
 
-from finitevolx._src.boundary.bc_1d import BoundaryCondition1D, Outflow1D, Periodic1D
+from finitevolx._src.boundary.bc_1d import (
+    BoundaryCondition1D,
+    Dirichlet1D,
+    Outflow1D,
+    Periodic1D,
+)
 
 
 class BoundaryConditionSet(eqx.Module):
@@ -24,12 +29,16 @@ class BoundaryConditionSet(eqx.Module):
         Boundary condition for the west ghost column.
     east : BoundaryCondition1D | None, optional
         Boundary condition for the east ghost column.
+    mask : Mask2D or Float[Array, "Ny Nx"] or None, optional
+        Domain mask.  When provided, solvers can extract it from the
+        BCSet instead of requiring a separate ``mask=`` argument.
     """
 
     south: BoundaryCondition1D | None = None
     north: BoundaryCondition1D | None = None
     west: BoundaryCondition1D | None = None
     east: BoundaryCondition1D | None = None
+    mask: object = None
 
     @classmethod
     def periodic(cls) -> BoundaryConditionSet:
@@ -39,6 +48,17 @@ class BoundaryConditionSet(eqx.Module):
             north=Periodic1D("north"),
             west=Periodic1D("west"),
             east=Periodic1D("east"),
+        )
+
+    @classmethod
+    def closed(cls, mask: object = None) -> BoundaryConditionSet:
+        """Return a zero-Dirichlet boundary-condition set on all faces."""
+        return cls(
+            south=Dirichlet1D("south", value=0.0),
+            north=Dirichlet1D("north", value=0.0),
+            west=Dirichlet1D("west", value=0.0),
+            east=Dirichlet1D("east", value=0.0),
+            mask=mask,
         )
 
     @classmethod

--- a/finitevolx/_src/boundary/bc_set.py
+++ b/finitevolx/_src/boundary/bc_set.py
@@ -52,7 +52,9 @@ class BoundaryConditionSet(eqx.Module):
         )
 
     @classmethod
-    def closed(cls, mask: Mask2D | Float[Array, "Ny Nx"] | None = None) -> BoundaryConditionSet:
+    def closed(
+        cls, mask: Mask2D | Float[Array, "Ny Nx"] | None = None
+    ) -> BoundaryConditionSet:
         """Return a zero-Dirichlet boundary-condition set on all faces."""
         return cls(
             south=Dirichlet1D("south", value=0.0),

--- a/finitevolx/_src/solvers/inhomogeneous.py
+++ b/finitevolx/_src/solvers/inhomogeneous.py
@@ -101,7 +101,7 @@ class SolveDomain(eqx.Module):
         self.boundary_ring = boundary_ring(mask_arr)
 
         if known_mask is not None:
-            self.all_known = self.boundary_ring | known_mask
+            self.all_known = self.boundary_ring | (known_mask & self.wet_mask)
         else:
             self.all_known = self.boundary_ring
 
@@ -181,4 +181,5 @@ class KnownValueLifting(eqx.Module):
         value_lift: Float[Array, "Ny Nx"],
     ) -> Float[Array, "Ny Nx"]:
         """Reconstruct full solution from homogeneous solve + lift."""
-        return value_lift + psi_hom
+        eff_f = self.domain.effective_mask.astype(psi_hom.dtype)
+        return value_lift + psi_hom * eff_f

--- a/finitevolx/_src/solvers/inhomogeneous.py
+++ b/finitevolx/_src/solvers/inhomogeneous.py
@@ -1,0 +1,184 @@
+"""Known-value lifting for inhomogeneous Dirichlet boundary conditions.
+
+Provides the building blocks for solving elliptic PDEs with prescribed
+(non-zero) values at boundary cells and/or sparse interior locations:
+
+Primitives
+----------
+:func:`boundary_ring` — identify the inner boundary ring (wet cells
+adjacent to at least one dry cell) from a binary mask.
+
+Operator API
+------------
+:class:`SolveDomain` — bundles all derived masks (boundary ring, all-known
+cells, effective solve domain) from a user mask + optional known_mask.
+
+:class:`KnownValueLifting` — pre/post-processing wrapper for the lifting
+trick.  Sandwiches any solver with RHS correction and reconstruction.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, Bool, Float
+
+from finitevolx._src.mask import Mask2D
+from finitevolx._src.solvers.iterative import masked_laplacian
+
+
+# ---------------------------------------------------------------------------
+# Primitive: boundary_ring
+# ---------------------------------------------------------------------------
+
+
+def boundary_ring(mask: Float[Array, "Ny Nx"]) -> Bool[Array, "Ny Nx"]:
+    """Wet cells adjacent to at least one dry cell (the inner ring).
+
+    Uses pad-then-slice to avoid ``jnp.roll`` wrap-around artifacts.
+    JIT-compatible but intended for offline (one-shot) use — the mask
+    is typically fixed at setup time.
+
+    Parameters
+    ----------
+    mask : Float[Array, "Ny Nx"]
+        Binary wet/dry mask (1 = wet, 0 = dry).
+
+    Returns
+    -------
+    Bool[Array, "Ny Nx"]
+        True at wet cells that neighbor at least one dry cell.
+    """
+    wet = mask > 0.5
+    dry = ~wet
+    padded_dry = jnp.pad(dry, pad_width=1, mode="constant", constant_values=False)
+    adjacent_to_dry = (
+        padded_dry[2:, 1:-1]      # south neighbor is dry
+        | padded_dry[:-2, 1:-1]   # north neighbor is dry
+        | padded_dry[1:-1, 2:]    # east neighbor is dry
+        | padded_dry[1:-1, :-2]   # west neighbor is dry
+    )
+    return wet & adjacent_to_dry
+
+
+# ---------------------------------------------------------------------------
+# SolveDomain
+# ---------------------------------------------------------------------------
+
+
+class SolveDomain(eqx.Module):
+    """Derived masks for the lifting trick.
+
+    Computes the inner boundary ring, merges with user-supplied
+    ``known_mask``, and partitions the wet domain into known cells and
+    the effective solve domain.
+
+    Parameters
+    ----------
+    mask : Float[Array, "Ny Nx"] or Mask2D
+        Binary wet/dry mask (1 = wet, 0 = dry).
+    known_mask : Bool[Array, "Ny Nx"] or None
+        Locations of additional known values (e.g., sparse interior
+        observations).  Merged with the auto-derived boundary ring.
+    """
+
+    wet_mask: Bool[Array, "Ny Nx"]
+    boundary_ring: Bool[Array, "Ny Nx"]
+    all_known: Bool[Array, "Ny Nx"]
+    effective_mask: Bool[Array, "Ny Nx"]
+
+    def __init__(
+        self,
+        mask: Float[Array, "Ny Nx"] | Mask2D,
+        known_mask: Bool[Array, "Ny Nx"] | None = None,
+    ):
+        if isinstance(mask, Mask2D):
+            mask_arr = jnp.asarray(mask.xy_corner_strict, dtype=jnp.float32)
+        else:
+            mask_arr = mask
+
+        self.wet_mask = mask_arr > 0.5
+        self.boundary_ring = boundary_ring(mask_arr)
+
+        if known_mask is not None:
+            self.all_known = self.boundary_ring | known_mask
+        else:
+            self.all_known = self.boundary_ring
+
+        self.effective_mask = self.wet_mask & ~self.all_known
+
+
+# ---------------------------------------------------------------------------
+# KnownValueLifting
+# ---------------------------------------------------------------------------
+
+
+class KnownValueLifting(eqx.Module):
+    """Pre/post-processing wrapper for the lifting trick.
+
+    Does **not** own or call a solver.  The user builds their solver
+    separately (with ``domain.effective_mask``) and calls it themselves.
+    This operator only sandwiches the solve with pre- and post-processing.
+
+    Parameters
+    ----------
+    domain : SolveDomain
+        Precomputed domain masks.
+    dx : float
+        Grid spacing in x.
+    dy : float
+        Grid spacing in y.
+    lambda_ : float
+        Helmholtz parameter.
+    """
+
+    domain: SolveDomain
+    dx: float = eqx.field(static=True)
+    dy: float = eqx.field(static=True)
+    lambda_: float = eqx.field(static=True)
+
+    def preprocess(
+        self,
+        rhs: Float[Array, "Ny Nx"],
+        known_values: Float[Array, "Ny Nx"],
+    ) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
+        """Correct RHS for known values.
+
+        Returns ``(rhs_corrected, value_lift)``.  Feed ``rhs_corrected``
+        to your solver, then pass both to :meth:`postprocess`.
+
+        Parameters
+        ----------
+        rhs : Float[Array, "Ny Nx"]
+            Original right-hand side.
+        known_values : Float[Array, "Ny Nx"]
+            Prescribed values at known cells.  Values at non-known cells
+            are ignored.
+
+        Returns
+        -------
+        rhs_corrected : Float[Array, "Ny Nx"]
+            Corrected RHS restricted to the effective solve domain.
+        value_lift : Float[Array, "Ny Nx"]
+            Lifting function — add to homogeneous solution to get the
+            full solution.
+        """
+        value_lift = jnp.where(self.domain.all_known, known_values, 0.0)
+
+        wet_mask_f = self.domain.wet_mask.astype(rhs.dtype)
+        A_lift = masked_laplacian(
+            value_lift, wet_mask_f, self.dx, self.dy, self.lambda_
+        )
+
+        eff_mask_f = self.domain.effective_mask.astype(rhs.dtype)
+        rhs_corrected = (rhs - A_lift) * eff_mask_f
+
+        return rhs_corrected, value_lift
+
+    def postprocess(
+        self,
+        psi_hom: Float[Array, "Ny Nx"],
+        value_lift: Float[Array, "Ny Nx"],
+    ) -> Float[Array, "Ny Nx"]:
+        """Reconstruct full solution from homogeneous solve + lift."""
+        return value_lift + psi_hom

--- a/finitevolx/_src/solvers/inhomogeneous.py
+++ b/finitevolx/_src/solvers/inhomogeneous.py
@@ -26,7 +26,6 @@ from jaxtyping import Array, Bool, Float
 from finitevolx._src.mask import Mask2D
 from finitevolx._src.solvers.iterative import masked_laplacian
 
-
 # ---------------------------------------------------------------------------
 # Primitive: boundary_ring
 # ---------------------------------------------------------------------------
@@ -53,10 +52,10 @@ def boundary_ring(mask: Float[Array, "Ny Nx"]) -> Bool[Array, "Ny Nx"]:
     dry = ~wet
     padded_dry = jnp.pad(dry, pad_width=1, mode="constant", constant_values=False)
     adjacent_to_dry = (
-        padded_dry[2:, 1:-1]      # south neighbor is dry
-        | padded_dry[:-2, 1:-1]   # north neighbor is dry
-        | padded_dry[1:-1, 2:]    # east neighbor is dry
-        | padded_dry[1:-1, :-2]   # west neighbor is dry
+        padded_dry[2:, 1:-1]  # south neighbor is dry
+        | padded_dry[:-2, 1:-1]  # north neighbor is dry
+        | padded_dry[1:-1, 2:]  # east neighbor is dry
+        | padded_dry[1:-1, :-2]  # west neighbor is dry
     )
     return wet & adjacent_to_dry
 

--- a/tests/test_inhomogeneous.py
+++ b/tests/test_inhomogeneous.py
@@ -1,0 +1,339 @@
+"""Tests for boundary_ring, SolveDomain, and KnownValueLifting."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import finitevolx as fvx
+from finitevolx._src.solvers.inhomogeneous import (
+    KnownValueLifting,
+    SolveDomain,
+    boundary_ring,
+)
+
+jax.config.update("jax_enable_x64", True)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _basin_mask(ny: int, nx: int) -> np.ndarray:
+    """Simple rectangular basin mask: wet interior, dry border."""
+    mask = np.zeros((ny, nx), dtype=np.float64)
+    mask[1:-1, 1:-1] = 1.0
+    return mask
+
+
+def _island_mask(ny: int, nx: int) -> np.ndarray:
+    """Basin with a 2x2 island in the middle."""
+    mask = _basin_mask(ny, nx)
+    cy, cx = ny // 2, nx // 2
+    mask[cy : cy + 2, cx : cx + 2] = 0.0
+    return mask
+
+
+# ---------------------------------------------------------------------------
+# boundary_ring
+# ---------------------------------------------------------------------------
+
+class TestBoundaryRing:
+    def test_simple_basin(self):
+        mask = jnp.array(_basin_mask(6, 8))
+        ring = boundary_ring(mask)
+
+        wet = mask > 0.5
+        interior = jnp.zeros_like(wet)
+        interior = interior.at[2:-2, 2:-2].set(True)
+
+        assert ring.dtype == jnp.bool_
+        assert ring.shape == mask.shape
+        # Ring cells are wet
+        assert jnp.all(ring <= wet)
+        # Interior cells are not in the ring
+        assert not jnp.any(ring & interior)
+        # All wet non-interior cells are in the ring
+        expected_ring = wet & ~interior
+        np.testing.assert_array_equal(ring, expected_ring)
+
+    def test_island_mask(self):
+        mask = jnp.array(_island_mask(10, 10))
+        ring = boundary_ring(mask)
+
+        wet = mask > 0.5
+        assert jnp.all(ring <= wet)
+
+        # Cells adjacent to the island should also be in the ring
+        cy, cx = 5, 5
+        # Check cells around the island (north/south/east/west of island)
+        island_neighbors = [
+            (cy - 1, cx), (cy - 1, cx + 1),     # north of island
+            (cy + 2, cx), (cy + 2, cx + 1),      # south of island
+            (cy, cx - 1), (cy + 1, cx - 1),      # west of island
+            (cy, cx + 2), (cy + 1, cx + 2),       # east of island
+        ]
+        for iy, ix in island_neighbors:
+            assert ring[iy, ix], f"Cell ({iy},{ix}) should be in ring (island neighbor)"
+
+    def test_all_wet_no_ring(self):
+        mask = jnp.ones((6, 8))
+        ring = boundary_ring(mask)
+        # No dry cells → no ring
+        assert not jnp.any(ring)
+
+    def test_all_dry_no_ring(self):
+        mask = jnp.zeros((6, 8))
+        ring = boundary_ring(mask)
+        assert not jnp.any(ring)
+
+    def test_single_wet_cell(self):
+        mask = jnp.zeros((5, 5))
+        mask = mask.at[2, 2].set(1.0)
+        ring = boundary_ring(mask)
+        # The single wet cell has dry neighbors → it's in the ring
+        assert ring[2, 2]
+        assert int(jnp.sum(ring)) == 1
+
+    def test_jit_compatible(self):
+        mask = jnp.array(_basin_mask(6, 8))
+        ring_eager = boundary_ring(mask)
+        ring_jit = jax.jit(boundary_ring)(mask)
+        np.testing.assert_array_equal(ring_eager, ring_jit)
+
+
+# ---------------------------------------------------------------------------
+# SolveDomain
+# ---------------------------------------------------------------------------
+
+class TestSolveDomain:
+    def test_partition_is_complete(self):
+        mask = jnp.array(_basin_mask(8, 8))
+        domain = SolveDomain(mask)
+
+        wet = mask > 0.5
+        # all_known and effective_mask are disjoint
+        assert not jnp.any(domain.all_known & domain.effective_mask)
+        # their union is the full wet domain
+        np.testing.assert_array_equal(
+            domain.all_known | domain.effective_mask, wet
+        )
+
+    def test_no_known_mask(self):
+        mask = jnp.array(_basin_mask(8, 8))
+        domain = SolveDomain(mask)
+        np.testing.assert_array_equal(domain.all_known, domain.boundary_ring)
+
+    def test_with_known_mask(self):
+        mask = jnp.array(_basin_mask(8, 8))
+        known_mask = jnp.zeros((8, 8), dtype=bool)
+        known_mask = known_mask.at[3, 3].set(True)
+
+        domain = SolveDomain(mask, known_mask=known_mask)
+
+        # Known mask cell is in all_known
+        assert domain.all_known[3, 3]
+        # But not in boundary_ring (it's interior)
+        assert not domain.boundary_ring[3, 3]
+        # And not in effective_mask (removed from solve domain)
+        assert not domain.effective_mask[3, 3]
+
+    def test_island_mask_finds_inner_rings(self):
+        mask = jnp.array(_island_mask(10, 10))
+        domain = SolveDomain(mask)
+
+        # Cells adjacent to island are in all_known (via boundary_ring)
+        cy, cx = 5, 5
+        assert domain.all_known[cy - 1, cx]
+        assert domain.all_known[cy + 2, cx]
+        # And not in effective_mask
+        assert not domain.effective_mask[cy - 1, cx]
+
+    def test_dry_known_mask_harmless(self):
+        mask = jnp.array(_basin_mask(8, 8))
+        known_mask = jnp.zeros((8, 8), dtype=bool)
+        known_mask = known_mask.at[0, 0].set(True)  # dry cell
+
+        domain = SolveDomain(mask, known_mask=known_mask)
+
+        # Dry cell in known_mask doesn't break anything
+        assert domain.all_known[0, 0]
+        # But it's not wet, so not in effective_mask either way
+        assert not domain.effective_mask[0, 0]
+
+
+# ---------------------------------------------------------------------------
+# KnownValueLifting
+# ---------------------------------------------------------------------------
+
+class TestKnownValueLifting:
+    def test_homogeneous_is_identity(self):
+        """known_values = 0 should produce rhs_corrected ≈ rhs on effective_mask."""
+        mask = jnp.array(_basin_mask(8, 8))
+        domain = SolveDomain(mask)
+        lifter = KnownValueLifting(domain=domain, dx=1.0, dy=1.0, lambda_=0.0)
+
+        rhs = jnp.ones((8, 8)) * mask
+        known_values = jnp.zeros((8, 8))
+
+        rhs_corrected, value_lift = lifter.preprocess(rhs, known_values)
+
+        # Lift is zero everywhere
+        np.testing.assert_allclose(value_lift, 0.0, atol=1e-15)
+        # Corrected RHS equals original RHS on the effective domain
+        eff = domain.effective_mask.astype(jnp.float64)
+        np.testing.assert_allclose(rhs_corrected, rhs * eff, atol=1e-12)
+
+    def test_postprocess_adds_lift(self):
+        mask = jnp.array(_basin_mask(8, 8))
+        domain = SolveDomain(mask)
+        lifter = KnownValueLifting(domain=domain, dx=1.0, dy=1.0, lambda_=0.0)
+
+        psi_hom = jnp.ones((8, 8)) * 2.0
+        value_lift = jnp.ones((8, 8)) * 3.0
+
+        psi = lifter.postprocess(psi_hom, value_lift)
+        np.testing.assert_allclose(psi, 5.0)
+
+    def test_manufactured_solution_cg(self):
+        """Verify the full lifting trick with a manufactured solution."""
+        Ny, Nx = 34, 34
+        dx = dy = 1.0 / (Ny - 2)
+        lambda_ = 4.0
+
+        mask = jnp.array(_basin_mask(Ny, Nx))
+        domain = SolveDomain(mask)
+        lifter = KnownValueLifting(domain=domain, dx=dx, dy=dy, lambda_=lambda_)
+
+        # Manufactured solution: doesn't vanish at boundaries
+        x = jnp.linspace(0, 1, Nx)
+        y = jnp.linspace(0, 1, Ny)
+        X, Y = jnp.meshgrid(x, y)
+        psi_exact = jnp.sin(jnp.pi * X) * jnp.sin(jnp.pi * Y) + 0.1 * jnp.sin(2 * jnp.pi * Y)
+
+        # Exact RHS: (∇² - λ)ψ
+        rhs_exact = fvx.masked_laplacian(psi_exact, mask, dx, dy, lambda_=lambda_)
+
+        # Known values at inner ring: exact solution values
+        known_values = jnp.where(domain.boundary_ring, psi_exact, 0.0)
+
+        # Pre-process
+        rhs_corrected, value_lift = lifter.preprocess(rhs_exact, known_values)
+
+        # Solve with CG on effective_mask
+        eff_mask_f = domain.effective_mask.astype(jnp.float64)
+
+        def matvec(x):
+            return fvx.masked_laplacian(x, eff_mask_f, dx, dy, lambda_=lambda_)
+
+        psi_hom, info = fvx.solve_cg(
+            matvec, rhs_corrected, rtol=1e-10, atol=1e-10, max_steps=2000
+        )
+        psi_hom = psi_hom * eff_mask_f
+
+        # Reconstruct
+        psi_numerical = lifter.postprocess(psi_hom, value_lift)
+
+        # Check error on effective_mask (interior solve cells)
+        error = jnp.abs(psi_numerical - psi_exact) * eff_mask_f
+        max_error = float(jnp.max(error))
+        assert max_error < 1e-3, f"Max error {max_error:.2e} exceeds tolerance"
+
+    def test_sparse_obs_pins_values(self):
+        """Verify that known_mask pins interior cells correctly."""
+        Ny, Nx = 16, 16
+        dx = dy = 1.0
+
+        mask = jnp.array(_basin_mask(Ny, Nx))
+
+        obs_mask = jnp.zeros((Ny, Nx), dtype=bool)
+        obs_mask = obs_mask.at[5, 5].set(True)
+        obs_mask = obs_mask.at[8, 10].set(True)
+
+        domain = SolveDomain(mask, known_mask=obs_mask)
+        lifter = KnownValueLifting(domain=domain, dx=dx, dy=dy, lambda_=0.0)
+
+        known_values = jnp.zeros((Ny, Nx))
+        known_values = known_values.at[5, 5].set(3.0)
+        known_values = known_values.at[8, 10].set(-2.0)
+
+        rhs = jnp.zeros((Ny, Nx))
+        rhs_corrected, value_lift = lifter.preprocess(rhs, known_values)
+
+        # Obs cells should appear in the lift
+        assert float(value_lift[5, 5]) == 3.0
+        assert float(value_lift[8, 10]) == -2.0
+
+        # Solve
+        eff_mask_f = domain.effective_mask.astype(jnp.float64)
+
+        def matvec(x):
+            return fvx.masked_laplacian(x, eff_mask_f, dx, dy, lambda_=0.0)
+
+        psi_hom, _ = fvx.solve_cg(matvec, rhs_corrected, rtol=1e-10, atol=1e-10)
+        psi_hom = psi_hom * eff_mask_f
+
+        psi = lifter.postprocess(psi_hom, value_lift)
+
+        # Observation cells should be pinned to their values
+        np.testing.assert_allclose(psi[5, 5], 3.0, atol=1e-10)
+        np.testing.assert_allclose(psi[8, 10], -2.0, atol=1e-10)
+
+    def test_jit_compatible(self):
+        mask = jnp.array(_basin_mask(8, 8))
+        domain = SolveDomain(mask)
+        lifter = KnownValueLifting(domain=domain, dx=1.0, dy=1.0, lambda_=0.0)
+
+        rhs = jnp.ones((8, 8)) * mask
+        kv = jnp.zeros((8, 8))
+
+        @jax.jit
+        def run(r, k):
+            return lifter.preprocess(r, k)
+
+        rhs_c, vlift = run(rhs, kv)
+        assert rhs_c.shape == (8, 8)
+        assert vlift.shape == (8, 8)
+
+
+# ---------------------------------------------------------------------------
+# BoundaryConditionSet.mask and .closed()
+# ---------------------------------------------------------------------------
+
+class TestBoundaryConditionSetMask:
+    def test_mask_field_default_none(self):
+        bc = fvx.BoundaryConditionSet()
+        assert bc.mask is None
+
+    def test_mask_field_accepts_array(self):
+        mask = jnp.ones((8, 8))
+        bc = fvx.BoundaryConditionSet(mask=mask)
+        assert bc.mask is not None
+
+    def test_closed_factory(self):
+        mask = jnp.ones((8, 8))
+        bc = fvx.BoundaryConditionSet.closed(mask=mask)
+        assert bc.mask is not None
+        assert isinstance(bc.south, fvx.Dirichlet1D)
+        assert isinstance(bc.north, fvx.Dirichlet1D)
+        assert isinstance(bc.west, fvx.Dirichlet1D)
+        assert isinstance(bc.east, fvx.Dirichlet1D)
+        assert bc.south.value == 0.0
+
+    def test_closed_factory_no_mask(self):
+        bc = fvx.BoundaryConditionSet.closed()
+        assert bc.mask is None
+        assert isinstance(bc.south, fvx.Dirichlet1D)
+
+    def test_existing_call_still_works(self):
+        bc = fvx.BoundaryConditionSet(
+            south=fvx.Periodic1D("south"),
+            north=fvx.Periodic1D("north"),
+            west=fvx.Periodic1D("west"),
+            east=fvx.Periodic1D("east"),
+        )
+        field = jnp.ones((6, 8))
+        result = bc(field, dx=1.0, dy=1.0)
+        assert result.shape == (6, 8)

--- a/tests/test_inhomogeneous.py
+++ b/tests/test_inhomogeneous.py
@@ -158,10 +158,14 @@ class TestSolveDomain:
 
         domain = SolveDomain(mask, known_mask=known_mask)
 
-        # Dry cell in known_mask doesn't break anything
-        assert domain.all_known[0, 0]
-        # But it's not wet, so not in effective_mask either way
+        # Dry cell in known_mask is filtered out (intersected with wet_mask)
+        assert not domain.all_known[0, 0]
         assert not domain.effective_mask[0, 0]
+        # Partition still holds
+        wet = mask > 0.5
+        np.testing.assert_array_equal(
+            domain.all_known | domain.effective_mask, wet
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -195,7 +199,10 @@ class TestKnownValueLifting:
         value_lift = jnp.ones((8, 8)) * 3.0
 
         psi = lifter.postprocess(psi_hom, value_lift)
-        np.testing.assert_allclose(psi, 5.0)
+        # postprocess masks psi_hom to effective_mask before adding lift
+        eff = domain.effective_mask
+        expected = value_lift + jnp.where(eff, 2.0, 0.0)
+        np.testing.assert_allclose(psi, expected)
 
     def test_manufactured_solution_cg(self):
         """Verify the full lifting trick with a manufactured solution."""

--- a/tests/test_inhomogeneous.py
+++ b/tests/test_inhomogeneous.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import numpy as np
-import pytest
 
 import finitevolx as fvx
 from finitevolx._src.solvers.inhomogeneous import (
@@ -20,6 +19,7 @@ jax.config.update("jax_enable_x64", True)
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 def _basin_mask(ny: int, nx: int) -> np.ndarray:
     """Simple rectangular basin mask: wet interior, dry border."""
@@ -39,6 +39,7 @@ def _island_mask(ny: int, nx: int) -> np.ndarray:
 # ---------------------------------------------------------------------------
 # boundary_ring
 # ---------------------------------------------------------------------------
+
 
 class TestBoundaryRing:
     def test_simple_basin(self):
@@ -70,10 +71,14 @@ class TestBoundaryRing:
         cy, cx = 5, 5
         # Check cells around the island (north/south/east/west of island)
         island_neighbors = [
-            (cy - 1, cx), (cy - 1, cx + 1),     # north of island
-            (cy + 2, cx), (cy + 2, cx + 1),      # south of island
-            (cy, cx - 1), (cy + 1, cx - 1),      # west of island
-            (cy, cx + 2), (cy + 1, cx + 2),       # east of island
+            (cy - 1, cx),
+            (cy - 1, cx + 1),  # north of island
+            (cy + 2, cx),
+            (cy + 2, cx + 1),  # south of island
+            (cy, cx - 1),
+            (cy + 1, cx - 1),  # west of island
+            (cy, cx + 2),
+            (cy + 1, cx + 2),  # east of island
         ]
         for iy, ix in island_neighbors:
             assert ring[iy, ix], f"Cell ({iy},{ix}) should be in ring (island neighbor)"
@@ -108,6 +113,7 @@ class TestBoundaryRing:
 # SolveDomain
 # ---------------------------------------------------------------------------
 
+
 class TestSolveDomain:
     def test_partition_is_complete(self):
         mask = jnp.array(_basin_mask(8, 8))
@@ -117,9 +123,7 @@ class TestSolveDomain:
         # all_known and effective_mask are disjoint
         assert not jnp.any(domain.all_known & domain.effective_mask)
         # their union is the full wet domain
-        np.testing.assert_array_equal(
-            domain.all_known | domain.effective_mask, wet
-        )
+        np.testing.assert_array_equal(domain.all_known | domain.effective_mask, wet)
 
     def test_no_known_mask(self):
         mask = jnp.array(_basin_mask(8, 8))
@@ -163,14 +167,13 @@ class TestSolveDomain:
         assert not domain.effective_mask[0, 0]
         # Partition still holds
         wet = mask > 0.5
-        np.testing.assert_array_equal(
-            domain.all_known | domain.effective_mask, wet
-        )
+        np.testing.assert_array_equal(domain.all_known | domain.effective_mask, wet)
 
 
 # ---------------------------------------------------------------------------
 # KnownValueLifting
 # ---------------------------------------------------------------------------
+
 
 class TestKnownValueLifting:
     def test_homogeneous_is_identity(self):
@@ -218,7 +221,9 @@ class TestKnownValueLifting:
         x = jnp.linspace(0, 1, Nx)
         y = jnp.linspace(0, 1, Ny)
         X, Y = jnp.meshgrid(x, y)
-        psi_exact = jnp.sin(jnp.pi * X) * jnp.sin(jnp.pi * Y) + 0.1 * jnp.sin(2 * jnp.pi * Y)
+        psi_exact = jnp.sin(jnp.pi * X) * jnp.sin(jnp.pi * Y) + 0.1 * jnp.sin(
+            2 * jnp.pi * Y
+        )
 
         # Exact RHS: (∇² - λ)ψ
         rhs_exact = fvx.masked_laplacian(psi_exact, mask, dx, dy, lambda_=lambda_)
@@ -235,7 +240,7 @@ class TestKnownValueLifting:
         def matvec(x):
             return fvx.masked_laplacian(x, eff_mask_f, dx, dy, lambda_=lambda_)
 
-        psi_hom, info = fvx.solve_cg(
+        psi_hom, _info = fvx.solve_cg(
             matvec, rhs_corrected, rtol=1e-10, atol=1e-10, max_steps=2000
         )
         psi_hom = psi_hom * eff_mask_f
@@ -308,6 +313,7 @@ class TestKnownValueLifting:
 # ---------------------------------------------------------------------------
 # BoundaryConditionSet.mask and .closed()
 # ---------------------------------------------------------------------------
+
 
 class TestBoundaryConditionSetMask:
     def test_mask_field_default_none(self):

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "finitevolx"
-version = "0.0.37"
+version = "0.0.40"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },
@@ -659,6 +659,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]


### PR DESCRIPTION
## Summary

Implements PR 1 of the unified BCs design from #213:

- **`boundary_ring(mask)`** — pad-then-slice primitive that identifies the inner ring (wet cells adjacent to at least one dry cell). Handles outer boundaries and island coasts. JIT-compatible.
- **`SolveDomain(mask, known_mask)`** — equinox Module that computes `boundary_ring`, merges with optional sparse observation locations (`known_mask`), and derives `effective_mask` (the actual solve domain).
- **`KnownValueLifting(domain, dx, dy, lambda_)`** — pre/post-processing wrapper for the generalized lifting trick. `preprocess()` corrects the RHS; `postprocess()` reconstructs the full solution.
- **`BoundaryConditionSet`** gains a `mask` field (default `None`, backward compatible) and a `closed()` factory method.
- All new symbols exported from `finitevolx.__init__`.

## Test plan

- [x] `boundary_ring`: simple basin, island mask, all-wet, all-dry, single cell, JIT compat (6 tests)
- [x] `SolveDomain`: partition completeness, no known_mask, with known_mask, island inner rings, dry known_mask harmless (5 tests)
- [x] `KnownValueLifting`: homogeneous identity, postprocess addition, manufactured solution with CG solver, sparse obs pinning, JIT compat (5 tests)
- [x] `BoundaryConditionSet`: mask field default, mask accepts array, closed factory (with/without mask), existing call backward compat (5 tests)
- [x] All 90 existing boundary tests pass (no regressions)

Closes #213

https://claude.ai/code/session_018hw4am1crVVpeYZPUB95Dw

---
_Generated by [Claude Code](https://claude.ai/code/session_018hw4am1crVVpeYZPUB95Dw)_