### PR TITLE
feat: add linear equation of state module

### DIFF
--- a/finitevolx/__init__.py
+++ b/finitevolx/__init__.py
@@ -110,14 +110,6 @@ from finitevolx._src.mask import (
 )
 from finitevolx._src.operators._ghost import interior
 from finitevolx._src.operators.coriolis import Coriolis2D, Coriolis3D
-from finitevolx._src.operators.eos import (
-    buoyancy,
-    linear_density,
-    linear_density_anomaly,
-    linear_drho_dS,
-    linear_drho_dT,
-    reduced_gravity,
-)
 from finitevolx._src.operators.diagnostics import (
     available_potential_energy,
     bernoulli_potential,
@@ -150,6 +142,14 @@ from finitevolx._src.operators.difference import (
     Difference3D,
 )
 from finitevolx._src.operators.divergence import Divergence2D, divergence_2d
+from finitevolx._src.operators.eos import (
+    buoyancy,
+    linear_density,
+    linear_density_anomaly,
+    linear_drho_dS,
+    linear_drho_dT,
+    reduced_gravity,
+)
 from finitevolx._src.operators.interpolation import (
     Interpolation1D,
     Interpolation2D,

--- a/finitevolx/__init__.py
+++ b/finitevolx/__init__.py
@@ -110,6 +110,14 @@ from finitevolx._src.mask import (
 )
 from finitevolx._src.operators._ghost import interior
 from finitevolx._src.operators.coriolis import Coriolis2D, Coriolis3D
+from finitevolx._src.operators.eos import (
+    buoyancy,
+    linear_density,
+    linear_density_anomaly,
+    linear_drho_dS,
+    linear_drho_dT,
+    reduced_gravity,
+)
 from finitevolx._src.operators.diagnostics import (
     available_potential_energy,
     bernoulli_potential,
@@ -541,6 +549,13 @@ __all__ = [
     "StencilCapability1D",
     "StencilCapability2D",
     "StencilCapability3D",
+    # Equation of state
+    "linear_density",
+    "linear_density_anomaly",
+    "linear_drho_dT",
+    "linear_drho_dS",
+    "buoyancy",
+    "reduced_gravity",
     # Diagnostics
     "available_potential_energy",
     "bernoulli_potential",

--- a/finitevolx/_src/operators/eos.py
+++ b/finitevolx/_src/operators/eos.py
@@ -5,7 +5,7 @@ partial derivatives, buoyancy, and reduced gravity from tracer fields.
 
 Phase 1 implements the **linear equation of state**::
 
-    ρ(T, S) = ρ₀ · (1 − α·(T − T₀) + β·(S − S₀))
+    ρ(T, S) = ρ₀ · (1 − α·(T − T_ref) + β·(S − S_ref))
 
 where α is the thermal expansion coefficient and β is the haline
 contraction coefficient.
@@ -30,7 +30,7 @@ def linear_density(
     r"""Compute density from temperature and salinity using a linear EOS.
 
     .. math::
-        \rho = \rho_0 \bigl(1 - \alpha\,(T - T_0) + \beta\,(S - S_0)\bigr)
+        \rho = \rho_0 \bigl(1 - \alpha\,(T - T_{\mathrm{ref}}) + \beta\,(S - S_{\mathrm{ref}})\bigr)
 
     Parameters
     ----------
@@ -69,7 +69,7 @@ def linear_density_anomaly(
     r"""Compute density anomaly ρ' = ρ − ρ₀ using a linear EOS.
 
     .. math::
-        \rho' = \rho_0 \bigl(-\alpha\,(T - T_0) + \beta\,(S - S_0)\bigr)
+        \rho' = \rho_0 \bigl(-\alpha\,(T - T_{\mathrm{ref}}) + \beta\,(S - S_{\mathrm{ref}})\bigr)
 
     Parameters
     ----------
@@ -182,9 +182,10 @@ def reduced_gravity(
     .. math::
         g' = g \, \frac{\rho_{\text{lower}} - \rho_{\text{upper}}}{\rho_0}
 
-    This is the input expected by
-    :func:`~finitevolx.build_coupling_matrix` for multi-layer
-    vertical-mode decomposition.
+    Computes the interface reduced gravity between two adjacent layers.
+    To build the ``g_prime`` vector expected by
+    :func:`~finitevolx.build_coupling_matrix`, compute this for each
+    interface and stack into a 1-D array of shape ``(nl,)``.
 
     Parameters
     ----------

--- a/finitevolx/_src/operators/eos.py
+++ b/finitevolx/_src/operators/eos.py
@@ -1,0 +1,206 @@
+"""Equation of state operators for ocean density from temperature and salinity.
+
+Provides functional operators for computing density, density anomaly,
+partial derivatives, buoyancy, and reduced gravity from tracer fields.
+
+Phase 1 implements the **linear equation of state**::
+
+    ρ(T, S) = ρ₀ · (1 − α·(T − T₀) + β·(S − S₀))
+
+where α is the thermal expansion coefficient and β is the haline
+contraction coefficient.
+"""
+
+from __future__ import annotations
+
+from jaxtyping import Array, Float
+
+from finitevolx._src.utils.constants import GRAVITY
+
+
+def linear_density(
+    T: Float[Array, "... Ny Nx"],
+    S: Float[Array, "... Ny Nx"],
+    rho_0: float = 1025.0,
+    alpha: float = 2e-4,
+    beta: float = 7e-4,
+    T_ref: float = 10.0,
+    S_ref: float = 35.0,
+) -> Float[Array, "... Ny Nx"]:
+    r"""Compute density from temperature and salinity using a linear EOS.
+
+    .. math::
+        \rho = \rho_0 \bigl(1 - \alpha\,(T - T_0) + \beta\,(S - S_0)\bigr)
+
+    Parameters
+    ----------
+    T : Float[Array, "... Ny Nx"]
+        Temperature (°C).
+    S : Float[Array, "... Ny Nx"]
+        Salinity (PSU).
+    rho_0 : float
+        Reference density (kg/m³).
+    alpha : float
+        Thermal expansion coefficient (1/K).
+    beta : float
+        Haline contraction coefficient (1/PSU).
+    T_ref : float
+        Reference temperature (°C).
+    S_ref : float
+        Reference salinity (PSU).
+
+    Returns
+    -------
+    Float[Array, "... Ny Nx"]
+        Density ρ (kg/m³).
+    """
+    return rho_0 * (1.0 - alpha * (T - T_ref) + beta * (S - S_ref))
+
+
+def linear_density_anomaly(
+    T: Float[Array, "... Ny Nx"],
+    S: Float[Array, "... Ny Nx"],
+    rho_0: float = 1025.0,
+    alpha: float = 2e-4,
+    beta: float = 7e-4,
+    T_ref: float = 10.0,
+    S_ref: float = 35.0,
+) -> Float[Array, "... Ny Nx"]:
+    r"""Compute density anomaly ρ' = ρ − ρ₀ using a linear EOS.
+
+    .. math::
+        \rho' = \rho_0 \bigl(-\alpha\,(T - T_0) + \beta\,(S - S_0)\bigr)
+
+    Parameters
+    ----------
+    T : Float[Array, "... Ny Nx"]
+        Temperature (°C).
+    S : Float[Array, "... Ny Nx"]
+        Salinity (PSU).
+    rho_0 : float
+        Reference density (kg/m³).
+    alpha : float
+        Thermal expansion coefficient (1/K).
+    beta : float
+        Haline contraction coefficient (1/PSU).
+    T_ref : float
+        Reference temperature (°C).
+    S_ref : float
+        Reference salinity (PSU).
+
+    Returns
+    -------
+    Float[Array, "... Ny Nx"]
+        Density anomaly ρ' = ρ − ρ₀ (kg/m³).
+    """
+    return rho_0 * (-alpha * (T - T_ref) + beta * (S - S_ref))
+
+
+def linear_drho_dT(
+    rho_0: float = 1025.0,
+    alpha: float = 2e-4,
+) -> float:
+    r"""Partial derivative ∂ρ/∂T for the linear EOS (constant).
+
+    .. math::
+        \frac{\partial\rho}{\partial T} = -\rho_0 \, \alpha
+
+    Parameters
+    ----------
+    rho_0 : float
+        Reference density (kg/m³).
+    alpha : float
+        Thermal expansion coefficient (1/K).
+
+    Returns
+    -------
+    float
+        ∂ρ/∂T (kg/(m³·K)).  Negative: warmer water is lighter.
+    """
+    return -rho_0 * alpha
+
+
+def linear_drho_dS(
+    rho_0: float = 1025.0,
+    beta: float = 7e-4,
+) -> float:
+    r"""Partial derivative ∂ρ/∂S for the linear EOS (constant).
+
+    .. math::
+        \frac{\partial\rho}{\partial S} = \rho_0 \, \beta
+
+    Parameters
+    ----------
+    rho_0 : float
+        Reference density (kg/m³).
+    beta : float
+        Haline contraction coefficient (1/PSU).
+
+    Returns
+    -------
+    float
+        ∂ρ/∂S (kg/(m³·PSU)).  Positive: saltier water is heavier.
+    """
+    return rho_0 * beta
+
+
+def buoyancy(
+    rho: Float[Array, "... Ny Nx"],
+    rho_0: float = 1025.0,
+    g: float = GRAVITY,
+) -> Float[Array, "... Ny Nx"]:
+    r"""Compute buoyancy from density.
+
+    .. math::
+        b = -\frac{g}{\rho_0}\,(\rho - \rho_0)
+
+    Parameters
+    ----------
+    rho : Float[Array, "... Ny Nx"]
+        Density (kg/m³).
+    rho_0 : float
+        Reference density (kg/m³).
+    g : float
+        Gravitational acceleration (m/s²).
+
+    Returns
+    -------
+    Float[Array, "... Ny Nx"]
+        Buoyancy (m/s²).  Positive when ρ < ρ₀ (lighter than reference).
+    """
+    return -g * (rho - rho_0) / rho_0
+
+
+def reduced_gravity(
+    rho_upper: Float[Array, "... Ny Nx"],
+    rho_lower: Float[Array, "... Ny Nx"],
+    rho_0: float = 1025.0,
+    g: float = GRAVITY,
+) -> Float[Array, "... Ny Nx"]:
+    r"""Compute reduced gravity between two layers.
+
+    .. math::
+        g' = g \, \frac{\rho_{\text{lower}} - \rho_{\text{upper}}}{\rho_0}
+
+    This is the input expected by
+    :func:`~finitevolx.build_coupling_matrix` for multi-layer
+    vertical-mode decomposition.
+
+    Parameters
+    ----------
+    rho_upper : Float[Array, "... Ny Nx"]
+        Density of the upper layer (kg/m³).
+    rho_lower : Float[Array, "... Ny Nx"]
+        Density of the lower layer (kg/m³).
+    rho_0 : float
+        Reference density (kg/m³).
+    g : float
+        Gravitational acceleration (m/s²).
+
+    Returns
+    -------
+    Float[Array, "... Ny Nx"]
+        Reduced gravity g' (m/s²).  Positive when the lower layer is
+        denser (stable stratification).
+    """
+    return g * (rho_lower - rho_upper) / rho_0

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -1,0 +1,190 @@
+"""Tests for the equation of state module."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from finitevolx._src.operators.eos import (
+    buoyancy,
+    linear_density,
+    linear_density_anomaly,
+    linear_drho_dS,
+    linear_drho_dT,
+    reduced_gravity,
+)
+
+jax.config.update("jax_enable_x64", True)
+
+RHO_0 = 1025.0
+ALPHA = 2e-4
+BETA = 7e-4
+T_REF = 10.0
+S_REF = 35.0
+
+
+class TestLinearDensity:
+    def test_reference_gives_rho0(self):
+        T = jnp.full((8, 8), T_REF)
+        S = jnp.full((8, 8), S_REF)
+        rho = linear_density(T, S)
+        np.testing.assert_allclose(rho, RHO_0, rtol=1e-12)
+
+    def test_warm_anomaly_decreases_density(self):
+        T = jnp.full((8, 8), T_REF + 1.0)
+        S = jnp.full((8, 8), S_REF)
+        rho = linear_density(T, S)
+        assert float(jnp.mean(rho)) < RHO_0
+
+    def test_salt_anomaly_increases_density(self):
+        T = jnp.full((8, 8), T_REF)
+        S = jnp.full((8, 8), S_REF + 1.0)
+        rho = linear_density(T, S)
+        assert float(jnp.mean(rho)) > RHO_0
+
+    def test_known_value(self):
+        T = jnp.full((4, 4), T_REF + 5.0)
+        S = jnp.full((4, 4), S_REF + 2.0)
+        rho = linear_density(T, S)
+        expected = RHO_0 * (1.0 - ALPHA * 5.0 + BETA * 2.0)
+        np.testing.assert_allclose(rho, expected, rtol=1e-12)
+
+    def test_batch_dims(self):
+        T = jnp.ones((3, 8, 8)) * T_REF
+        S = jnp.ones((3, 8, 8)) * S_REF
+        rho = linear_density(T, S)
+        assert rho.shape == (3, 8, 8)
+        np.testing.assert_allclose(rho, RHO_0, rtol=1e-12)
+
+    def test_jit_compatible(self):
+        T = jnp.full((8, 8), T_REF + 1.0)
+        S = jnp.full((8, 8), S_REF)
+        rho_eager = linear_density(T, S)
+        rho_jit = jax.jit(linear_density)(T, S)
+        np.testing.assert_allclose(rho_eager, rho_jit, rtol=1e-12)
+
+
+class TestLinearDensityAnomaly:
+    def test_reference_gives_zero(self):
+        T = jnp.full((8, 8), T_REF)
+        S = jnp.full((8, 8), S_REF)
+        rho_prime = linear_density_anomaly(T, S)
+        np.testing.assert_allclose(rho_prime, 0.0, atol=1e-12)
+
+    def test_warm_anomaly_is_negative(self):
+        T = jnp.full((8, 8), T_REF + 1.0)
+        S = jnp.full((8, 8), S_REF)
+        rho_prime = linear_density_anomaly(T, S)
+        assert float(jnp.mean(rho_prime)) < 0.0
+
+    def test_salt_anomaly_is_positive(self):
+        T = jnp.full((8, 8), T_REF)
+        S = jnp.full((8, 8), S_REF + 1.0)
+        rho_prime = linear_density_anomaly(T, S)
+        assert float(jnp.mean(rho_prime)) > 0.0
+
+    def test_equals_density_minus_rho0(self):
+        T = jnp.full((8, 8), T_REF + 3.0)
+        S = jnp.full((8, 8), S_REF - 1.0)
+        rho = linear_density(T, S)
+        rho_prime = linear_density_anomaly(T, S)
+        np.testing.assert_allclose(rho_prime, rho - RHO_0, rtol=1e-12)
+
+
+class TestLinearDrhoDT:
+    def test_sign_is_negative(self):
+        assert linear_drho_dT() < 0.0
+
+    def test_known_value(self):
+        expected = -RHO_0 * ALPHA
+        np.testing.assert_allclose(linear_drho_dT(), expected, rtol=1e-12)
+
+    def test_custom_params(self):
+        np.testing.assert_allclose(
+            linear_drho_dT(rho_0=1000.0, alpha=1e-4), -0.1, rtol=1e-12
+        )
+
+
+class TestLinearDrhoDS:
+    def test_sign_is_positive(self):
+        assert linear_drho_dS() > 0.0
+
+    def test_known_value(self):
+        expected = RHO_0 * BETA
+        np.testing.assert_allclose(linear_drho_dS(), expected, rtol=1e-12)
+
+    def test_custom_params(self):
+        np.testing.assert_allclose(
+            linear_drho_dS(rho_0=1000.0, beta=1e-3), 1.0, rtol=1e-12
+        )
+
+
+class TestBuoyancy:
+    def test_reference_density_gives_zero(self):
+        rho = jnp.full((8, 8), RHO_0)
+        b = buoyancy(rho)
+        np.testing.assert_allclose(b, 0.0, atol=1e-12)
+
+    def test_lighter_gives_positive(self):
+        rho = jnp.full((8, 8), RHO_0 - 1.0)
+        b = buoyancy(rho)
+        assert float(jnp.mean(b)) > 0.0
+
+    def test_heavier_gives_negative(self):
+        rho = jnp.full((8, 8), RHO_0 + 1.0)
+        b = buoyancy(rho)
+        assert float(jnp.mean(b)) < 0.0
+
+    def test_known_value(self):
+        g = 9.80665
+        rho = jnp.full((4, 4), RHO_0 + 0.5)
+        b = buoyancy(rho)
+        expected = -g * 0.5 / RHO_0
+        np.testing.assert_allclose(b, expected, rtol=1e-12)
+
+    def test_jit_compatible(self):
+        rho = jnp.full((8, 8), RHO_0 + 1.0)
+        b_eager = buoyancy(rho)
+        b_jit = jax.jit(buoyancy)(rho)
+        np.testing.assert_allclose(b_eager, b_jit, rtol=1e-12)
+
+
+class TestReducedGravity:
+    def test_equal_layers_gives_zero(self):
+        rho = jnp.full((8, 8), RHO_0)
+        gp = reduced_gravity(rho, rho)
+        np.testing.assert_allclose(gp, 0.0, atol=1e-12)
+
+    def test_stable_stratification_positive(self):
+        rho_up = jnp.full((8, 8), RHO_0)
+        rho_dn = jnp.full((8, 8), RHO_0 + 1.0)
+        gp = reduced_gravity(rho_up, rho_dn)
+        assert float(jnp.mean(gp)) > 0.0
+
+    def test_unstable_stratification_negative(self):
+        rho_up = jnp.full((8, 8), RHO_0 + 1.0)
+        rho_dn = jnp.full((8, 8), RHO_0)
+        gp = reduced_gravity(rho_up, rho_dn)
+        assert float(jnp.mean(gp)) < 0.0
+
+    def test_known_value(self):
+        g = 9.80665
+        rho_up = jnp.full((4, 4), 1024.0)
+        rho_dn = jnp.full((4, 4), 1026.0)
+        gp = reduced_gravity(rho_up, rho_dn)
+        expected = g * 2.0 / RHO_0
+        np.testing.assert_allclose(gp, expected, rtol=1e-12)
+
+    def test_batch_dims(self):
+        rho_up = jnp.full((3, 8, 8), RHO_0)
+        rho_dn = jnp.full((3, 8, 8), RHO_0 + 1.0)
+        gp = reduced_gravity(rho_up, rho_dn)
+        assert gp.shape == (3, 8, 8)
+
+    def test_jit_compatible(self):
+        rho_up = jnp.full((8, 8), RHO_0)
+        rho_dn = jnp.full((8, 8), RHO_0 + 1.0)
+        gp_eager = reduced_gravity(rho_up, rho_dn)
+        gp_jit = jax.jit(reduced_gravity)(rho_up, rho_dn)
+        np.testing.assert_allclose(gp_eager, gp_jit, rtol=1e-12)

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "finitevolx"
-version = "0.0.40"
+version = "0.0.41"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },


### PR DESCRIPTION
## Summary

- Add `finitevolx/_src/operators/eos.py` with 6 functions for computing ocean density from T/S tracers using the linear equation of state
- `linear_density(T, S)` — ρ = ρ₀(1 − α(T−T₀) + β(S−S₀))
- `linear_density_anomaly(T, S)` — ρ' = ρ − ρ₀
- `linear_drho_dT` / `linear_drho_dS` — constant partial derivatives
- `buoyancy(rho)` — b = −g(ρ−ρ₀)/ρ₀
- `reduced_gravity(rho_upper, rho_lower)` — g' = gΔρ/ρ₀, bridges to `build_coupling_matrix`
- All support arbitrary leading dims for multi-layer use, defaults follow Veros conventions

Phase 1 of #83. Nonlinear TEOS-10 deferred to follow-up PR.

## Test plan

- [x] `linear_density`: reference→ρ₀, warm→lighter, salt→heavier, known value, batch dims, JIT (6 tests)
- [x] `linear_density_anomaly`: reference→0, warm→negative, salt→positive, equals ρ−ρ₀ (4 tests)
- [x] `linear_drho_dT`: negative sign, known value, custom params (3 tests)
- [x] `linear_drho_dS`: positive sign, known value, custom params (3 tests)
- [x] `buoyancy`: reference→0, lighter→positive, heavier→negative, known value, JIT (5 tests)
- [x] `reduced_gravity`: equal→0, stable→positive, unstable→negative, known value, batch, JIT (6 tests)
- [x] Lint clean (ruff check + ruff format)

Closes #83

https://claude.ai/code/session_018hw4am1crVVpeYZPUB95Dw

---
_Generated by [Claude Code](https://claude.ai/code/session_018hw4am1crVVpeYZPUB95Dw)_