### PR TITLE
feat(operators): add massh gap-analysis note and the operators it proposes

### DIFF
--- a/docs/design/research/massh_gap_analysis.md
+++ b/docs/design/research/massh_gap_analysis.md
@@ -112,7 +112,15 @@ def rusanov_flux(
 
 Re-export it flat in `finitevolx/__init__.py` (and add to `__all__`), exactly like the existing
 `uv_center_flux` / `divergence_2d`. Keep `eps` exposed: `eps=0` recovers the textbook flux;
-`eps>0` is the AD-safe variant. The divergence of the flux reuses `divergence_2d`.
+`eps>0` is the AD-safe variant.
+
+!!! warning "Reduced-shape output — `divergence_2d` does not apply directly"
+    `rusanov_flux` returns the `N−1` face values along `axis` (e.g. `(Ny, Nx−1)` for
+    `axis=-1`), **not** a full ghost-padded C-grid array. finitevolX's `divergence_2d`
+    expects both inputs to be full `[Ny, Nx]` arrays with the ghost ring (it takes
+    `diff_x_bwd`/`diff_y_bwd` internally), so it cannot consume the reduced output.
+    Take the continuity divergence by differencing the faces along the same axis (see
+    the example), or embed the fluxes into ghost-padded arrays first.
 
 ### Example
 
@@ -121,11 +129,20 @@ import finitevolx as fvx
 import jax.numpy as jnp
 
 h  = jnp.array(...)                                   # (Ny, Nx) on h-grid
-u  = jnp.array(...)                                   # face-normal velocity
-Fx = fvx.rusanov_flux(h, u, axis=-1, eps=1e-8)        # flat API
-Fy = fvx.rusanov_flux(h, v, axis=-2, eps=1e-8)
-dhdt = -fvx.divergence_2d(Fx, Fy, dx, dy)             # existing op (flat)
+u  = jnp.array(...)                                   # face-normal velocity, x-faces
+v  = jnp.array(...)                                   # face-normal velocity, y-faces
+Fx = fvx.rusanov_flux(h, u, axis=-1, eps=1e-8)        # (Ny, Nx-1) east-face flux
+Fy = fvx.rusanov_flux(h, v, axis=-2, eps=1e-8)        # (Ny-1, Nx) north-face flux
+# Continuity tendency at interior T-cells (reduced-shape divergence of the faces):
+dhdt = jnp.zeros_like(h)
+dhdt = dhdt.at[1:-1, 1:-1].set(
+    -(
+        (Fx[1:-1, 1:] - Fx[1:-1, :-1]) / dx
+        + (Fy[1:, 1:-1] - Fy[:-1, 1:-1]) / dy
+    )
+)
 ```
+
 
 -----
 
@@ -195,8 +212,11 @@ def pv_flux_arakawa_lamb(                 # thin free-function wrapper over the 
 ```
 
 Ship the conservation property as a **test**, not a promise: an `enstrophy_conservation_residual`
-diagnostic that shows `d/dt Σ q²/2 → 0` to round-off in a closed basin. (Note `potential_enstrophy`
-already exists in `diagnostics.py:332` to build that check on.)
+diagnostic that shows `d/dt Σ ½ h q² → 0` to round-off in a closed basin. Use the
+*thickness-weighted* potential enstrophy `Σ ½ h q²` — the physical shallow-water invariant
+Arakawa–Lamb conserves — **not** the unweighted `Σ q²/2`, which a correct flux need not conserve
+when `h` varies in space. The existing `potential_enstrophy(q, h)` (`diagnostics.py:332`, returns
+`0.5 * q² * h`) already takes the thickness field, so build the check on it directly.
 
 ### Example
 
@@ -272,13 +292,28 @@ def barotropic_filter(
     u_star, v_star,                  # provisional velocities (after explicit RHS)
     h_u, h_v,                        # layer thickness on u-/v-faces
     *, dx, dy, g, tau, dt,
-    helm_solve: Callable,            # e.g. build_multigrid_solver(..., coeff=h).solve
+    helm_solve: Callable,            # the solver itself, e.g. build_multigrid_solver(..., coeff=h)
 ) -> tuple[Array, Array]:
     """Subtract the implicit external-gravity-wave (barotropic) mode.
     Returns (filt_u, filt_v) tendency corrections. See MASSH sw.py:1019.
     The variable-coef Helmholtz ∇·(h∇w) is provided by the existing
     multigrid solver (build_multigrid_solver(coeff=...))."""
 ```
+
+`helm_solve` is **called as a plain callable** (`helm_solve(rhs)`). Pass the
+`MultigridSolver` *object* returned by `build_multigrid_solver(...)` — it is callable via
+`__call__` (there is no `.solve` method; the other entry points are `solve_onestep` /
+`solve_unrolled`).
+
+!!! warning "Coefficient is frozen at solver-construction time"
+    `build_multigrid_solver(coeff=h)` converts `coeff` to NumPy, interpolates it to the
+    staggered face coefficients `cx`/`cy`, and **freezes** them in the level hierarchy when
+    the solver is built. MASSH, by contrast, passes the current `coef_ugrid`/`coef_vgrid`
+    into every solve. So a prebuilt `helm_solve` is only correct when the barotropic
+    coefficient is **time-invariant**. If `h_u`/`h_v` evolve, either (a) treat the
+    coefficient as fixed (a common, well-justified barotropic-mode approximation), or
+    (b) rebuild the solver each step (cheap relative to the solve), or (c) extend the
+    solver with a per-step-coefficient interface. The signature above assumes (a)/(b).
 
 So this gap is **a thin operator over an existing solver**, not new elliptic machinery. (It is
 the same variable-coef use-case flagged on the spectraldiffx side; finitevolX is the better home

--- a/docs/design/research/massh_gap_analysis.md
+++ b/docs/design/research/massh_gap_analysis.md
@@ -1,0 +1,439 @@
+# finitevolX — Gap Analysis vs. MASSH (VarDyn branch)
+
+**Scope:** primitives and operators only. Reference: `leguillf/MASSH@VarDyn`, model cores
+`mapping/models/model_qgsw/` (shallow-water) and `mapping/models/model_qg1l/` (QG1L).
+**Date:** 2026-06-05.
+
+This document is self-contained: each gap states the math, shows the MASSH reference
+implementation (with `file:line`), proposes a `finitevolx` API, and gives a worked example.
+The proposals are written against the existing Arakawa-C-grid / Equinox style in
+`finitevolx/_src/operators/` and `_src/advection/`.
+
+!!! warning "Provenance of references"
+    The finitevolX-side claims in this doc were **verified against the local source on `main`**
+    (version `0.0.42`, 2026-06-05) with concrete `file:line` citations and verbatim signatures.
+    The MASSH `file:line` citations come from the upstream `VarDyn` branch and were **not**
+    re-verified — treat them as pointers, not exact-line guarantees.
+
+!!! important "Two conventions this doc corrects relative to an earlier draft"
+    1. **The public API is flat, not namespaced.** `finitevolx/__init__.py` re-exports every
+       symbol at the top level (`fvx.divergence_2d`, `fvx.Advection2D`, `fvx.MomentumAdvection2D`).
+       There are **no** `fvx.operators.*` / `fvx.advection.*` submodule namespaces — the earlier
+       draft's `fvx.operators.divergence_2d(...)` / `fvx.advection.rusanov_flux(...)` would raise
+       `AttributeError`. All examples below use the real flat form.
+    2. **The energy/enstrophy-conserving SW vorticity scheme already exists** (see §2). The earlier
+       draft listed Arakawa–Lamb (1981) as the headline gap; it is in fact implemented. The
+       residual §2 gap is narrower.
+
+-----
+
+## 0. What is NOT a gap (so you don't re-scope it)
+
+Confirmed present in finitevolX, equal to or stronger than MASSH (paths verified):
+
+| Capability | finitevolX (verified) | MASSH equivalent |
+|---|---|---|
+| Conservative Arakawa Jacobian (1966) | `operators/jacobian.py:22` `arakawa_jacobian` | — (MASSH uses upwind vort. advection only) |
+| WENO 3/5/7/9 (+ one-sided `_right`) | `advection/weno.py:297–666`, `advection/reconstruction.py` | `reconstruction.py` WENO-Z 4/6 only |
+| Flux limiters (minmod / van_leer / superbee / mc) | `advection/limiters.py:34–123` | — |
+| C-grid PV (single + multilayer) | `operators/diagnostics.py` `potential_vorticity:150`, `sw_potential_vorticity:828`, `sw_potential_vorticity_multilayer:873` | scattered in `sw.py` |
+| KE / Bernoulli / Okubo–Weiss / enstrophy | `operators/diagnostics.py` `kinetic_energy:35`, `bernoulli_potential:76`, `okubo_weiss:274`, `enstrophy:308`, `potential_enstrophy:332` | `finite_diff.py::comp_ke` only |
+| **Energy/enstrophy-conserving SW vortex-force** | `operators/vorticity.py:202` `Vorticity2D.pv_flux_arakawa_lamb` (+ `pv_flux_energy_conserving:128`, `pv_flux_enstrophy_conserving:163`); `diffusion/momentum.py:35` `MomentumAdvection2D` (Sadourny E/Z + AL81 blend) | dissipative upwind only |
+| Elliptic stack (CG, capacitance, MG, spectral) + PV inversion | `_src/solvers/*` (incl. **variable-coefficient** multigrid `∇·(c∇u)`) | `helmholtz.py`, `helmholtz_multigrid.py` |
+| Split-explicit barotropic/baroclinic time-stepping | `timestepping/split_explicit.py:23` `split_explicit_step` | barotropic *filter* (§3) |
+| SSP-RK3 (functional + diffrax) | `timestepping/explicit_rk.py:70` `rk3_ssp_step`; `timestepping/diffrax_solvers.py:102` `RK3SSP` | — |
+
+So the gaps below are genuinely net-new operators, **not** reimplementations — with the
+important caveat that §2 is narrower than the earlier draft claimed.
+
+-----
+
+## 1. Rusanov / local Lax–Friedrichs flux for the continuity equation  *(real gap)*
+
+**Status: genuine gap.** No Rusanov / local Lax–Friedrichs / smooth-abs flux exists anywhere in
+`advection/` (`face_flux.py`, `flux.py`, `linear.py` checked; grep for `rusanov`/`lax`/`llf`
+returns nothing).
+
+### Why
+
+The continuity/height flux path is reconstruction-based (WENO). MASSH keeps a separate
+**first-order monotone Rusanov flux** for `h` because WENO's nonlinear smoothness weights make
+the *adjoint* fragile — the differentiable-DA use case. A Rusanov flux is the standard robust
+fallback and a low-dissipation-budget baseline.
+
+### Math
+
+For a conserved scalar `q` advected at face velocity `a` across face `i+½`, the local
+Lax–Friedrichs (Rusanov) numerical flux is
+
+$$
+F_{i+\frac12} = \tfrac12\,a\,(q_L + q_R) - \tfrac12\,|a|\,(q_R - q_L),
+$$
+
+where `q_L, q_R` are the cell values either side of the face and `|a|` is the local maximum
+wave speed (here `|a|`). The dissipation term `½|a|(q_R−q_L)` makes it monotone. For AD
+stability the absolute value is replaced by the smooth surrogate `|a| ≈ √(a²+ε²)` (the
+`smooth_abs` of §5).
+
+### MASSH reference
+
+`mapping/models/model_qgsw/sw.py:674` — `_h_flux_rusanov1`:
+
+```python
+def _h_flux_rusanov1(self, h_tot_phys, velocity, dim):
+    # First-order conservative Rusanov flux for h-continuity. Monotone;
+    # avoids WENO smoothness weights, which make adjoints fragile.
+    h_left, h_right = ((h_tot_phys[..., :, :-1], h_tot_phys[..., :, 1:]) if dim == -1
+                       else (h_tot_phys[..., :-1, :], h_tot_phys[..., 1:, :]))
+    speed = smooth_abs(velocity)                       # √(v²+ε²)
+    return 0.5*velocity*(h_left+h_right) - 0.5*speed*(h_right-h_left)
+```
+
+with `smooth_abs` at `mapping/models/model_qgsw/reconstruction.py:15`.
+
+### Proposed finitevolX API
+
+Add to `finitevolx/_src/advection/face_flux.py` (it already holds `uv_center_flux`,
+`uv_node_flux`; the upwind path lives in `flux.py::upwind_flux`):
+
+```python
+def rusanov_flux(
+    q: Float[Array, "..."],          # cell-centered scalar (h-grid)
+    a: Float[Array, "..."],          # face-normal velocity on the same axis
+    axis: int = -1,
+    eps: float = 1e-8,               # smooth-abs floor; set 0 for hard |a|
+) -> Float[Array, "..."]:
+    """Local Lax–Friedrichs (Rusanov) flux at faces along `axis`.
+
+    F = ½ a (q_L + q_R) − ½ |a|_eps (q_R − q_L),  |a|_eps = sqrt(a² + eps²).
+    Returns the flux on the (N−1) interior faces along `axis`.
+    """
+```
+
+Re-export it flat in `finitevolx/__init__.py` (and add to `__all__`), exactly like the existing
+`uv_center_flux` / `divergence_2d`. Keep `eps` exposed: `eps=0` recovers the textbook flux;
+`eps>0` is the AD-safe variant. The divergence of the flux reuses `divergence_2d`.
+
+### Example
+
+```python
+import finitevolx as fvx
+import jax.numpy as jnp
+
+h  = jnp.array(...)                                   # (Ny, Nx) on h-grid
+u  = jnp.array(...)                                   # face-normal velocity
+Fx = fvx.rusanov_flux(h, u, axis=-1, eps=1e-8)        # flat API
+Fy = fvx.rusanov_flux(h, v, axis=-2, eps=1e-8)
+dhdt = -fvx.divergence_2d(Fx, Fy, dx, dy)             # existing op (flat)
+```
+
+-----
+
+## 2. Upwind vorticity-flux operator + a public AL81 free function  *(narrowed gap)*
+
+!!! warning "The conservative scheme already exists"
+    The earlier draft listed the Arakawa–Lamb (1981) energy- and enstrophy-conserving SW scheme
+    as the headline gap. **It is already implemented** in finitevolX:
+    `operators/vorticity.py:202` `Vorticity2D.pv_flux_arakawa_lamb` (a weighted blend of
+    `pv_flux_energy_conserving:128` and `pv_flux_enstrophy_conserving:163`), and the
+    momentum-level operator `diffusion/momentum.py:35` `MomentumAdvection2D` offers the Sadourny
+    (1975) E-scheme, Z-scheme, and the AL81 blend via a `scheme=` argument — citing
+    *Arakawa & Lamb (1981), MWR 109, 18–36* in its docstring. Both are in the public `__all__`.
+
+### What is actually missing
+
+1. **The MASSH-parity *upwind* vorticity flux** (`_omega_adv_upwind3/5`) — a *dissipative*
+   reconstruction of (absolute) vorticity for the vortex-force term. finitevolX has the
+   *conserving* schemes but no upwind vorticity-advection operator (grep `vorticity_flux`,
+   `omega_adv` → nothing public). Useful as a robust, cheap baseline and for parity with MASSH.
+2. **A public free-function wrapper** for the AL81 flux. Today it is a *method* on `Vorticity2D`;
+   a thin `pv_flux_arakawa_lamb(q, U, V, alpha=1/3)` free function (matching the `divergence_2d`
+   style) would make it reachable without instantiating the class.
+
+### Math
+
+In vector-invariant SW the momentum tendency carries `q (k × (h u))` with `q = (ζ+f)/h` and
+mass flux `h u`. Arakawa–Lamb (1981) discretize this so the operator conserves total energy and
+total potential enstrophy simultaneously; the upwind alternative instead reconstructs vorticity
+at faces with an order-3/5 upwind stencil (dissipative). MASSH advects *absolute* vorticity
+`ω+f` (it folds `f` into the PV); AL81 does the same with `q=(ζ+f)/h`.
+
+### MASSH reference (the upwind variant — the parity target)
+
+`mapping/models/model_qgsw/sw.py:753` — `_omega_adv_upwind3` (3rd-order upwind on corners):
+
+```python
+#   vel > 0: omega_face = (-omega[j-1] + 5*omega[j]   + 2*omega[j+1]) / 6
+#   vel < 0: omega_face = ( 2*omega[j] + 5*omega[j+1] -   omega[j+2]) / 6
+```
+
+used at `sw.py:690` `advection_momentum`:
+
+```python
+omega_Vm, omega_Um = self._omega_adv_upwind3(omega, U_m, V_m)
+dt_u =  omega_Vm + self.fstar_ugrid[..., 1:-1, :] * V_m
+dt_v = -(omega_Um + self.fstar_vgrid[..., 1:-1]   * U_m)
+```
+
+### Proposed finitevolX API
+
+```python
+# finitevolx/_src/operators/vorticity.py  (alongside Vorticity2D)
+def vorticity_flux_upwind(
+    omega: Float[Array, "Ny1 Nx1"],   # absolute vorticity on cell corners (q-grid)
+    U: Float[Array, "Ny Nx1"],        # mass flux on u-faces  (h·u)
+    V: Float[Array, "Ny1 Nx"],        # mass flux on v-faces  (h·v)
+    order: int = 3,                   # 3 or 5
+) -> tuple[Float[Array, "Ny Nx1"], Float[Array, "Ny1 Nx"]]:
+    """Upwind vortex-force fluxes (omega_V on u-eqn, omega_U on v-eqn).
+    Matches MASSH sw.py::_omega_adv_upwind{3,5}. Dissipative."""
+
+def pv_flux_arakawa_lamb(                 # thin free-function wrapper over the existing method
+    q: Float[Array, "Ny1 Nx1"], U, V, *, alpha: float = 1.0 / 3.0,
+) -> tuple[Float[Array, "Ny Nx1"], Float[Array, "Ny1 Nx"]]:
+    """Public free-function form of Vorticity2D.pv_flux_arakawa_lamb (AL81)."""
+```
+
+Ship the conservation property as a **test**, not a promise: an `enstrophy_conservation_residual`
+diagnostic that shows `d/dt Σ q²/2 → 0` to round-off in a closed basin. (Note `potential_enstrophy`
+already exists in `diagnostics.py:332` to build that check on.)
+
+### Example
+
+```python
+import finitevolx as fvx
+# conserving form via the existing class (works today):
+vort = fvx.Vorticity2D(grid=grid, mask=None)
+pv   = fvx.sw_potential_vorticity(u, v, h, f, dx, dy)        # existing diagnostic
+U, V = h_u * u, h_v * v                                      # mass fluxes
+CAu, CAv = vort.pv_flux_arakawa_lamb(pv, U, V)               # energy+enstrophy conserving
+# or the MASSH-parity dissipative baseline (the §2 gap):
+omega_V, omega_U = fvx.vorticity_flux_upwind(omega_abs, U, V, order=3)
+```
+
+-----
+
+## 3. Barotropic-mode (external gravity wave) filter / split  *(operator gap; infrastructure present)*
+
+!!! note "The hard parts already exist"
+    finitevolX already has (a) **variable-coefficient** multigrid for `∇·(c∇u) − λu = rhs`
+    (`solvers/multigrid.py`, factory `build_multigrid_solver(..., coeff=...)`; the per-face
+    coefficients are `cx`/`cy` from `_interpolate_coeff_to_faces`, **not** the
+    `coef_ugrid`/`coef_vgrid` the earlier draft named), and (b) a **split-explicit**
+    barotropic/baroclinic time-stepper (`timestepping/split_explicit.py:23` `split_explicit_step`)
+    plus vertical-mode decomposition (`vertical/vertical_modes.py`). What is missing is the
+    specific *implicit barotropic filter operator*; the solver and the mode machinery it needs
+    are already there, so this is **wiring + one operator**, not new solver math.
+
+### Why
+
+For multi-layer SW the external gravity wave sets a punishing CFL. MASSH includes an implicit
+barotropic filter that solves a Helmholtz problem for the barotropic surface mode each step and
+subtracts its fast component, letting you take baroclinic-scale time steps.
+
+### Math
+
+Split the depth-averaged (barotropic) velocity `ū = Σ_k h_k u_k / Σ_k h_k`. The fast
+surface-mode correction `w` solves a variable-coefficient Helmholtz/Poisson problem
+
+$$
+\frac{1}{g\,\tau\,\Delta t}\,\nabla\!\cdot(h\,\bar{u}^{*}) \;=\; \nabla\!\cdot(h\,\nabla w),
+\qquad
+\mathrm{filt}_u = -g\,\tau\,\partial_x w,\quad \mathrm{filt}_v = -g\,\tau\,\partial_y w,
+$$
+
+added back to the momentum tendency so the divergent fast part is treated implicitly. `τ` is an
+implicitness/relaxation parameter.
+
+### MASSH reference
+
+`mapping/models/model_qgsw/sw.py:1019` — `filter_barotropic_waves`:
+
+```python
+u_bar_star = (u_star*h_tot_ugrid).sum(-3, keepdims=True)/h_tot_ugrid.sum(-3, keepdims=True)
+v_bar_star = (v_star*h_tot_vgrid).sum(-3, keepdims=True)/h_tot_vgrid.sum(-3, keepdims=True)
+rhs = 1./(self.g*self.dt*self.tau) * ( jnp.diff(h_tot_ugrid*u_bar_star, -2)/self.dx
+                                     + jnp.diff(h_tot_vgrid*v_bar_star, -1)/self.dy )
+w_surf_imp = self.helm_solver.solve(rhs, coef_ugrid, coef_vgrid)   # variable-coef Helmholtz
+filt_u = -self.g*self.tau*jnp.diff(w_surf_imp, -2)
+filt_v = -self.g*self.tau*jnp.diff(w_surf_imp, -1)
+return dt_u+filt_u, dt_v+filt_v, dt_h
+```
+
+(Inspired by Dukowicz & Smith free-surface split, `doi:10.1029/2000JC900089`.)
+
+### Proposed finitevolX API
+
+A model-level operator that calls the *existing* variable-coef multigrid:
+
+```python
+# finitevolx/_src/operators/barotropic.py
+def barotropic_filter(
+    u_star, v_star,                  # provisional velocities (after explicit RHS)
+    h_u, h_v,                        # layer thickness on u-/v-faces
+    *, dx, dy, g, tau, dt,
+    helm_solve: Callable,            # e.g. build_multigrid_solver(..., coeff=h).solve
+) -> tuple[Array, Array]:
+    """Subtract the implicit external-gravity-wave (barotropic) mode.
+    Returns (filt_u, filt_v) tendency corrections. See MASSH sw.py:1019.
+    The variable-coef Helmholtz ∇·(h∇w) is provided by the existing
+    multigrid solver (build_multigrid_solver(coeff=...))."""
+```
+
+So this gap is **a thin operator over an existing solver**, not new elliptic machinery. (It is
+the same variable-coef use-case flagged on the spectraldiffx side; finitevolX is the better home
+because its multigrid already does `∇·(c∇u)`.)
+
+-----
+
+## 4. Linear drag and Rayleigh-sponge relaxation operators  *(real gap)*
+
+**Status: genuine gap.** Grep for `linear_drag`, `bottom_drag`, `rayleigh`, `relaxation`,
+`sponge`, `nudg`, `restoring` across `_src/` finds only (a) the multigrid Jacobi-smoother
+"relaxation" weight (unrelated) and (b) a 1-D `Sponge1D` boundary condition (`boundary/bc_1d.py`)
+— **no 2-D relaxation/drag tendency operator**. The diffusion module (`Diffusion2D`,
+`BiharmonicDiffusion2D`) provides Laplacian/biharmonic dissipation but no linear drag.
+
+### Why
+
+MASSH treats **bottom drag**, **sponge/Rayleigh damping**, and **BC nudging** as first-class RHS
+terms. These are needed for closed-basin spin-down, sponge boundaries, and BFN, and they are the
+cross-cutting "nudging primitive" of §6.
+
+### Math
+
+- Linear (Rayleigh) bottom drag on the lowest layer: `∂_t u_N += −r u_N`.
+- Sponge/relaxation toward a reference `X_ref` with a spatial weight `W∈[0,1]`:
+  `∂_t X += −γ W (X − X_ref)`.
+
+### MASSH reference
+
+Bottom drag, `mapping/models/model_qgsw/sw.py:967`:
+
+```python
+def add_bottom_drag(self, du, dv, u, v):
+    du = du.at[..., -1, :, :].set(du[..., -1, :, :] - self.bottom_drag_coef*u[..., -1, 1:-1, :])
+    dv = dv.at[..., -1, :, :].set(dv[..., -1, :, :] - self.bottom_drag_coef*v[..., -1, :, 1:-1])
+    return du, dv
+```
+
+Sponge nudging in QG1L (`mapping/models/model_qg1l/jqgm.py`): `sponge_coef * Wbc * (Xb − X)`,
+with `Wbc` a boundary weight map.
+
+### Proposed finitevolX API
+
+```python
+# finitevolx/_src/operators/relaxation.py
+def linear_drag(u, v, *, coef, layer=-1) -> tuple[Array, Array]:
+    """Rayleigh bottom drag −coef·u on the chosen layer (default deepest)."""
+
+def rayleigh_relaxation(
+    x: Array, x_ref: Array, *, coef: float, weight: Array
+) -> Array:
+    """Sponge/relaxation tendency −coef·weight·(x − x_ref).
+    `weight` is a [0,1] spatial map. One operator behind sponge layers, BC
+    forcing, BFN nudging, and tracer restoring. MASSH: jqgm.py sponge term."""
+```
+
+Re-export both flat in `__init__.py`. `rayleigh_relaxation` is the single operator behind sponge
+layers, BC forcing, BFN nudging, and tracer restoring — define once, reuse everywhere.
+
+!!! note "This is the operator the somax tracer-transport gap needs"
+    The companion somax gap analysis flags `forcing_tracer_from_bc` and notes that no
+    `rayleigh_relaxation` op exists anywhere yet. **This §4 is that operator's home.** Landing it
+    here unblocks tracer-to-BC nudging in somax without per-model bespoke code.
+
+### Example
+
+```python
+import finitevolx as fvx
+du, dv = fvx.linear_drag(u, v, coef=r)
+dssh   = fvx.rayleigh_relaxation(ssh, ssh_bc, coef=gamma, weight=Wbc)
+```
+
+-----
+
+## 5. Differentiable positivity / monotonicity guards  *(real gap)*
+
+**Status: genuine gap.** `operators/_utils.py` holds only `_safe_div_cos` (a spherical pole
+guard); grep for `smooth_abs`, `smooth_clamp`, `smooth_max`, `softplus` across `_src/` finds
+nothing.
+
+### Why
+
+Adjoints break where `jnp.maximum`, `jnp.abs`, or hard clamps appear (zero/undefined gradient).
+MASSH uses smooth surrogates so the SW adjoint stays well-defined — directly relevant to the
+differentiable-baseline goal. Tiny, but they belong as named, tested primitives so they are used
+consistently (and `rusanov_flux` (§1) depends on `smooth_abs`).
+
+### Math
+
+- `smooth_abs(x) = √(x² + ε²)`  (wave speeds, WENO weights).
+- `smooth_clamp(x, x_min) = x_min + softplus((x−x_min)·s)/s`  (positive layer thickness).
+
+### MASSH reference
+
+`sw.py:27` `smooth_clamp`, `reconstruction.py:15` `smooth_abs`:
+
+```python
+def smooth_clamp(x, x_min, sharpness=10.):
+    return x_min + jax.nn.softplus((x - x_min)*sharpness)/sharpness    # grad nonzero everywhere
+
+def smooth_abs(x):
+    return jnp.sqrt(x**2 + WENO_EPS**2)
+```
+
+### Proposed finitevolX API
+
+```python
+# finitevolx/_src/operators/differentiable.py  (new; or extend operators/_utils.py)
+def smooth_abs(x, eps=1e-8): ...
+def smooth_clamp(x, x_min, sharpness=10.0): ...
+def smooth_max(x, y, sharpness=10.0): ...      # generic two-arg variant
+```
+
+Document the gradient behavior in each docstring (the entire point). Re-export flat.
+
+-----
+
+## 6. Cross-cutting note: the relaxation/nudging primitive
+
+§4 (sponge/drag), the weight map (xrtoolz), and the Gaspari–Cohn taper (gaussx) are three faces
+of one concept:
+
+$$
+\text{tendency} \mathrel{+}= \text{coef}\cdot W(x)\cdot (X_{\text{ref}} - X),
+$$
+
+with `W` a smooth spatial weight. MASSH uses this exact pattern for sponge layers, BC forcing,
+tracer restoring, **and** BFN. Implementing `rayleigh_relaxation` here + `compute_weight_map` in
+xrtoolz + `gaspari_cohn` in gaussx closes the most gaps per unit effort and is the prerequisite
+for the `BFNCycle` protocol proposed in the pipekit doc.
+
+-----
+
+## Suggested ordering for finitevolX
+
+1. `smooth_abs` / `smooth_clamp` (§5) — trivial; unblocks AD-safe versions of everything else
+   (and `rusanov_flux` needs `smooth_abs`).
+2. `rusanov_flux` (§1) — small, immediately useful as an AD-robust continuity flux.
+3. `rayleigh_relaxation` + `linear_drag` (§4) — unblocks sponge/BC/BFN (and the somax tracer
+   nudging gap).
+4. `vorticity_flux_upwind` + the public `pv_flux_arakawa_lamb` wrapper (§2) — MASSH parity and a
+   one-call conserving entry point (the conserving *scheme* already exists).
+5. `barotropic_filter` (§3) — a thin operator over the existing variable-coef multigrid.
+
+## References
+
+- Arakawa & Lamb (1981), *Mon. Wea. Rev.* 109, 18–36 — energy/enstrophy-conserving SW scheme
+  (**already implemented**: `operators/vorticity.py:202`, `diffusion/momentum.py:35`).
+- Arakawa (1966), *J. Comput. Phys.* 1 — the Jacobian (`operators/jacobian.py:22`).
+- Sadourny (1975) — the E/Z schemes finitevolX's `MomentumAdvection2D` also offers.
+- Dukowicz & Smith (2000), `doi:10.1029/2000JC900089` — barotropic split (MASSH's cited source).
+- **finitevolX (verified, `0.0.42`):** `operators/jacobian.py`, `advection/weno.py`,
+  `advection/limiters.py`, `advection/face_flux.py`, `operators/diagnostics.py`,
+  `operators/vorticity.py`, `operators/divergence.py`, `solvers/multigrid.py`
+  (`build_multigrid_solver(coeff=...)`), `timestepping/split_explicit.py`,
+  `timestepping/explicit_rk.py` / `diffrax_solvers.py`.
+- **MASSH (`VarDyn`, unverified line numbers):** `mapping/models/model_qgsw/sw.py`,
+  `reconstruction.py`; `mapping/models/model_qg1l/jqgm.py`.

--- a/finitevolx/__init__.py
+++ b/finitevolx/__init__.py
@@ -1,5 +1,9 @@
 from finitevolx._src.advection.advection import Advection1D, Advection2D, Advection3D
-from finitevolx._src.advection.face_flux import uv_center_flux, uv_node_flux
+from finitevolx._src.advection.face_flux import (
+    rusanov_flux,
+    uv_center_flux,
+    uv_node_flux,
+)
 from finitevolx._src.advection.flux import upwind_flux
 from finitevolx._src.advection.limiters import mc, minmod, superbee, van_leer
 from finitevolx._src.advection.linear import (
@@ -109,6 +113,7 @@ from finitevolx._src.mask import (
     StencilCapability3D,
 )
 from finitevolx._src.operators._ghost import interior
+from finitevolx._src.operators.barotropic import barotropic_filter
 from finitevolx._src.operators.coriolis import Coriolis2D, Coriolis3D
 from finitevolx._src.operators.diagnostics import (
     available_potential_energy,
@@ -140,6 +145,11 @@ from finitevolx._src.operators.difference import (
     Difference1D,
     Difference2D,
     Difference3D,
+)
+from finitevolx._src.operators.differentiable import (
+    smooth_abs,
+    smooth_clamp,
+    smooth_max,
 )
 from finitevolx._src.operators.divergence import Divergence2D, divergence_2d
 from finitevolx._src.operators.eos import (
@@ -176,6 +186,7 @@ from finitevolx._src.operators.reductions import (
     volume_sum,
     volume_weights,
 )
+from finitevolx._src.operators.relaxation import linear_drag, rayleigh_relaxation
 from finitevolx._src.operators.spherical_compound import (
     SphericalDivergence2D,
     SphericalDivergence3D,
@@ -214,7 +225,12 @@ from finitevolx._src.operators.stencils import (
     diff_y_fwd,
     diff_y_fwd_3d,
 )
-from finitevolx._src.operators.vorticity import Vorticity2D, Vorticity3D
+from finitevolx._src.operators.vorticity import (
+    Vorticity2D,
+    Vorticity3D,
+    pv_flux_arakawa_lamb,
+    vorticity_flux_upwind,
+)
 from finitevolx._src.solvers.elliptic import (
     # Types
     BoundaryCondition,
@@ -379,6 +395,7 @@ __all__ = [
     # Raw face fluxes
     "uv_center_flux",
     "uv_node_flux",
+    "rusanov_flux",
     # Advection
     "Advection1D",
     "Advection2D",
@@ -594,6 +611,17 @@ __all__ = [
     # Vorticity
     "Vorticity2D",
     "Vorticity3D",
+    "pv_flux_arakawa_lamb",
+    "vorticity_flux_upwind",
+    # Barotropic-mode filter
+    "barotropic_filter",
+    # Linear drag / Rayleigh relaxation
+    "linear_drag",
+    "rayleigh_relaxation",
+    # Differentiable surrogates
+    "smooth_abs",
+    "smooth_clamp",
+    "smooth_max",
     # Vertical coupling and mode transforms
     "build_coupling_matrix",
     "decompose_vertical_modes",

--- a/finitevolx/_src/advection/face_flux.py
+++ b/finitevolx/_src/advection/face_flux.py
@@ -20,6 +20,7 @@ See Also
 
 from __future__ import annotations
 
+import jax.numpy as jnp
 from jaxtyping import Array, Float
 
 from finitevolx._src.advection.advection import (
@@ -31,6 +32,7 @@ from finitevolx._src.advection.flux import upwind_flux
 from finitevolx._src.advection.reconstruction import Reconstruction2D
 from finitevolx._src.grid.cartesian import CartesianGrid2D
 from finitevolx._src.mask import Mask2D
+from finitevolx._src.operators.differentiable import smooth_abs
 
 
 def uv_center_flux(
@@ -125,6 +127,79 @@ def uv_node_flux(
     """
     recon = Reconstruction2D(grid=grid)
     return _compute_face_fluxes(recon, q, u, v, method, mask)
+
+
+def rusanov_flux(
+    q: Float[Array, "..."],
+    a: Float[Array, "..."],
+    axis: int = -1,
+    eps: float = 1e-8,
+) -> Float[Array, "..."]:
+    r"""Local Lax--Friedrichs (Rusanov) numerical flux at faces along ``axis``.
+
+    For a conserved scalar ``q`` advected at face-normal velocity ``a``, the
+    Rusanov flux at the face between two adjacent cells is
+
+    .. math::
+
+        F = \tfrac12\, a\, (q_L + q_R) - \tfrac12\, |a|_\varepsilon\, (q_R - q_L),
+        \qquad |a|_\varepsilon = \sqrt{a^2 + \varepsilon^2},
+
+    where ``q_L``/``q_R`` are the cell values on either side of the face.  The
+    dissipation term :math:`\tfrac12 |a| (q_R - q_L)` makes the flux monotone
+    (first-order, no reconstruction).  This is the standard robust, AD-friendly
+    fallback for the continuity/height flux: unlike WENO it has no nonlinear
+    smoothness weights, so its adjoint stays well-conditioned.
+
+    The absolute value uses the smooth surrogate :func:`smooth_abs`
+    (:math:`\sqrt{a^2 + \varepsilon^2}`) so the dissipation term is
+    differentiable at ``a = 0``.  Pass ``eps=0`` to recover the exact textbook
+    flux with a hard :func:`jax.numpy.abs` (non-smooth at ``a = 0``).
+
+    Parameters
+    ----------
+    q : Float[Array, "..."]
+        Cell-centred scalar (e.g. layer thickness on the h-grid), including
+        any ghost ring.  Reconstructed left/right values are the adjacent
+        cells along ``axis``.
+    a : Float[Array, "..."]
+        Face-normal advecting velocity sampled at the ``N - 1`` faces along
+        ``axis`` (i.e. broadcastable to ``q`` with one fewer element along
+        ``axis``).  Following the MASSH convention, ``a`` already lives on the
+        faces; no interpolation is performed here.
+    axis : int, optional
+        Axis along which to take the flux.  Default ``-1`` (x / east faces);
+        use ``-2`` for y / north faces.
+    eps : float, optional
+        Smoothing floor for ``|a|``.  ``eps > 0`` (default ``1e-8``) gives the
+        AD-safe variant; ``eps == 0`` gives the exact non-smooth flux.
+
+    Returns
+    -------
+    Float[Array, "..."]
+        Numerical flux on the ``N - 1`` interior faces along ``axis``.  The
+        divergence of the flux can be taken with :func:`divergence_2d`.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> from finitevolx import rusanov_flux
+    >>> h = jnp.ones((6, 6))
+    >>> u = jnp.ones((6, 5))  # face-normal velocity on the 5 x-faces
+    >>> fx = rusanov_flux(h, u, axis=-1)
+    >>> fx.shape
+    (6, 5)
+    """
+    ndim = q.ndim
+    ax = axis % ndim
+    left = [slice(None)] * ndim
+    right = [slice(None)] * ndim
+    left[ax] = slice(None, -1)
+    right[ax] = slice(1, None)
+    q_l = q[tuple(left)]
+    q_r = q[tuple(right)]
+    speed = smooth_abs(a, eps) if eps > 0.0 else jnp.abs(a)
+    return 0.5 * a * (q_l + q_r) - 0.5 * speed * (q_r - q_l)
 
 
 def _compute_face_fluxes(

--- a/finitevolx/_src/advection/face_flux.py
+++ b/finitevolx/_src/advection/face_flux.py
@@ -177,8 +177,11 @@ def rusanov_flux(
     Returns
     -------
     Float[Array, "..."]
-        Numerical flux on the ``N - 1`` interior faces along ``axis``.  The
-        divergence of the flux can be taken with :func:`divergence_2d`.
+        Numerical flux on the ``N - 1`` interior faces along ``axis``.  This is
+        a reduced-shape array (one fewer element along ``axis``), **not** a full
+        ghost-padded C-grid field, so :func:`divergence_2d` (which expects full
+        ``[Ny, Nx]`` inputs) does not apply to it directly — take the divergence
+        by differencing the faces along the same axis instead.
 
     Examples
     --------

--- a/finitevolx/_src/operators/barotropic.py
+++ b/finitevolx/_src/operators/barotropic.py
@@ -1,0 +1,136 @@
+"""
+Implicit barotropic-mode (external gravity wave) filter for multi-layer
+shallow water.
+
+For a stacked multi-layer model the external (barotropic) gravity wave sets a
+punishing CFL.  This operator implements the implicit filter of
+Dukowicz & Smith (2000), as used in MASSH ``sw.py::filter_barotropic_waves``:
+it forms the depth-integrated (barotropic) provisional transport, solves a
+single variable-coefficient Helmholtz problem for the fast surface mode, and
+returns the momentum-tendency correction that removes the divergent fast part
+implicitly — letting the caller take baroclinic-scale time steps.
+
+The hard part — the variable-coefficient Helmholtz solve ``div(h grad w)`` —
+is **not** re-implemented here: it is injected as ``helm_solve``, which the
+caller builds from the existing multigrid solver
+(``build_multigrid_solver(mask, dx, dy, coeff=h)``, which is itself callable).
+This module is the thin operator that wires the transport, the solve, and the
+gradient correction together.
+
+References
+----------
+Dukowicz, J. K. & Smith, R. D. (1994/2000). Implicit free-surface method for
+the Bryan-Cox-Semtner ocean model. doi:10.1029/2000JC900089.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from finitevolx._src.operators._ghost import interior
+from finitevolx._src.operators.divergence import divergence_2d
+from finitevolx._src.operators.stencils import diff_x_fwd, diff_y_fwd
+
+
+def barotropic_filter(
+    u_star: Float[Array, "Nz Ny Nx"],
+    v_star: Float[Array, "Nz Ny Nx"],
+    h_u: Float[Array, "Nz Ny Nx"],
+    h_v: Float[Array, "Nz Ny Nx"],
+    *,
+    dx: float,
+    dy: float,
+    g: float,
+    tau: float,
+    dt: float,
+    helm_solve: Callable[[Float[Array, "Ny Nx"]], Float[Array, "Ny Nx"]],
+    layer_axis: int = -3,
+) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
+    r"""Implicit external-gravity-wave (barotropic) mode filter.
+
+    Given the provisional velocities ``u_star`` / ``v_star`` (after the
+    explicit RHS) and the per-layer thicknesses on the velocity faces, this:
+
+    1. forms the barotropic (depth-summed) provisional mass transport
+       ``U_bt = sum_k h_u u*`` on U-faces and ``V_bt = sum_k h_v v*`` on
+       V-faces;
+    2. builds the Helmholtz right-hand side
+       :math:`\text{rhs} = \frac{1}{g\,\tau\,\Delta t}\, \nabla\!\cdot(U_{bt}, V_{bt})`;
+    3. solves the variable-coefficient Helmholtz problem
+       :math:`\nabla\!\cdot(h\,\nabla w) = \text{rhs}` via the injected
+       ``helm_solve``;
+    4. returns the implicit fast-mode momentum correction
+       :math:`\text{filt}_u = -g\,\tau\,\partial_x w`,
+       :math:`\text{filt}_v = -g\,\tau\,\partial_y w`.
+
+    The returned corrections are single-layer (barotropic) fields the caller
+    adds back to every layer's momentum tendency, e.g. ``dt_u += filt_u``.
+
+    Parameters
+    ----------
+    u_star, v_star : Float[Array, "Nz Ny Nx"]
+        Provisional velocities at U-/V-points, stacked over layers.
+    h_u, h_v : Float[Array, "Nz Ny Nx"]
+        Layer thicknesses interpolated to U-/V-points.
+    dx, dy : float
+        Grid spacing.
+    g : float
+        Gravitational acceleration (or reduced gravity for the barotropic
+        mode).
+    tau : float
+        Implicitness / relaxation parameter of the filter.
+    dt : float
+        Time step.
+    helm_solve : Callable[[Array], Array]
+        Solver for the variable-coefficient Helmholtz problem
+        ``div(h grad w) = rhs`` at T-points, e.g. a
+        :class:`~finitevolx.MultigridSolver` built with ``coeff=h`` (the
+        solver object is itself callable).
+    layer_axis : int, optional
+        Axis to sum the layers over.  Default ``-3``.
+
+    Returns
+    -------
+    tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]
+        ``(filt_u, filt_v)`` — barotropic momentum-tendency corrections at
+        U-/V-points, ghost ring zero.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> from finitevolx import barotropic_filter
+    >>> u = jnp.zeros((2, 8, 8))
+    >>> h = jnp.ones((2, 8, 8))
+    >>> # quiescent flow -> zero correction (helm_solve never sees divergence)
+    >>> fu, fv = barotropic_filter(
+    ...     u,
+    ...     u,
+    ...     h,
+    ...     h,
+    ...     dx=1.0,
+    ...     dy=1.0,
+    ...     g=9.81,
+    ...     tau=1.0,
+    ...     dt=1.0,
+    ...     helm_solve=lambda rhs: rhs,
+    ... )
+    >>> bool((fu == 0).all())
+    True
+    """
+    # Barotropic (depth-summed) provisional mass transport on the faces.
+    u_bt = jnp.sum(h_u * u_star, axis=layer_axis)  # (Ny, Nx) on U-faces
+    v_bt = jnp.sum(h_v * v_star, axis=layer_axis)  # (Ny, Nx) on V-faces
+
+    # Divergence of the barotropic transport, scaled into the Helmholtz RHS.
+    rhs = divergence_2d(u_bt, v_bt, dx, dy) / (g * tau * dt)
+
+    # Solve the variable-coefficient Helmholtz problem for the surface mode.
+    w = helm_solve(rhs)
+
+    # Implicit fast-mode correction: minus the (scaled) gradient of w at faces.
+    filt_u = interior(-g * tau * diff_x_fwd(w) / dx, w)
+    filt_v = interior(-g * tau * diff_y_fwd(w) / dy, w)
+    return filt_u, filt_v

--- a/finitevolx/_src/operators/barotropic.py
+++ b/finitevolx/_src/operators/barotropic.py
@@ -69,6 +69,20 @@ def barotropic_filter(
     The returned corrections are single-layer (barotropic) fields the caller
     adds back to every layer's momentum tendency, e.g. ``dt_u += filt_u``.
 
+    ``helm_solve`` is invoked as a plain callable (``helm_solve(rhs)``); pass
+    the :class:`~finitevolx.MultigridSolver` object itself (it is callable via
+    ``__call__``).
+
+    .. note::
+        :func:`~finitevolx.build_multigrid_solver` **freezes** the coefficient
+        (interpolated to the staggered ``cx``/``cy`` face fields) into the level
+        hierarchy at construction time.  A prebuilt ``helm_solve`` therefore
+        solves with a *fixed* coefficient; it is correct only when the
+        barotropic coefficient is time-invariant.  If ``h_u``/``h_v`` evolve,
+        either accept the fixed-coefficient (frozen-``h``) barotropic
+        approximation or rebuild the solver each step — do not reuse a stale
+        solver across changing thicknesses.
+
     Parameters
     ----------
     u_star, v_star : Float[Array, "Nz Ny Nx"]

--- a/finitevolx/_src/operators/differentiable.py
+++ b/finitevolx/_src/operators/differentiable.py
@@ -1,0 +1,113 @@
+"""Differentiable surrogates for non-smooth operations.
+
+Adjoints break wherever ``jnp.abs``, ``jnp.maximum``, or a hard clamp appears:
+those have a zero or undefined gradient at the kink, which corrupts the
+reverse-mode pass that differentiable data-assimilation (4DVar, BFN) relies on.
+
+This module provides smooth, everywhere-differentiable surrogates:
+
+* :func:`smooth_abs` — ``sqrt(x**2 + eps**2)``, a rounded ``|x|`` used for
+  wave speeds (e.g. the Rusanov flux, :func:`finitevolx.rusanov_flux`) and
+  reconstruction smoothness weights.
+* :func:`smooth_clamp` — a softplus-based ``max(x, x_min)`` with a nonzero
+  gradient everywhere, used to keep layer thicknesses positive.
+* :func:`smooth_max` — the generic two-argument variant of the above.
+
+All three are pure ``jax.numpy`` and compose with ``jit`` / ``vmap`` / ``grad``.
+The ``eps`` / ``sharpness`` knobs trade approximation error against gradient
+conditioning: smaller ``eps`` (larger ``sharpness``) is closer to the
+non-smooth function but has a stiffer gradient near the kink.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+
+def smooth_abs(
+    x: Float[Array, "..."],
+    eps: float = 1e-8,
+) -> Float[Array, "..."]:
+    r"""Smooth approximation of ``|x|`` with a nonzero gradient at the origin.
+
+    Computes :math:`\sqrt{x^2 + \varepsilon^2}`. Unlike :func:`jax.numpy.abs`,
+    whose gradient is undefined at ``x = 0``, this has the well-defined
+    derivative :math:`x / \sqrt{x^2 + \varepsilon^2}` everywhere, so it is safe
+    inside a differentiated RHS (e.g. the dissipation term of a Rusanov flux).
+
+    Parameters
+    ----------
+    x : Float[Array, "..."]
+        Input array.
+    eps : float, optional
+        Rounding scale. As ``eps -> 0`` the result approaches ``|x|``; the
+        maximum deviation is ``eps`` (attained at ``x = 0``). Default ``1e-8``.
+
+    Returns
+    -------
+    Float[Array, "..."]
+        ``sqrt(x**2 + eps**2)``, same shape as ``x``.
+    """
+    return jnp.sqrt(x * x + eps * eps)
+
+
+def smooth_clamp(
+    x: Float[Array, "..."],
+    x_min: float | Float[Array, "..."],
+    sharpness: float = 10.0,
+) -> Float[Array, "..."]:
+    r"""Smooth approximation of ``max(x, x_min)`` (a soft lower clamp).
+
+    Computes :math:`x_{\min} + \mathrm{softplus}\big((x - x_{\min})\,s\big) / s`
+    with sharpness ``s``. The gradient w.r.t. ``x`` is the logistic
+    :math:`\sigma\big((x - x_{\min})\,s\big)`, which is strictly positive
+    everywhere — so, unlike ``jnp.maximum(x, x_min)`` (zero gradient below the
+    clamp) or a hard clip, this never zeroes the backward pass. Used to keep a
+    layer thickness ``h`` strictly positive without killing its sensitivity.
+
+    Parameters
+    ----------
+    x : Float[Array, "..."]
+        Input array.
+    x_min : float or Float[Array, "..."]
+        Lower bound. The result is always ``> x_min`` and approaches
+        ``max(x, x_min)`` as ``sharpness -> inf``.
+    sharpness : float, optional
+        Transition sharpness ``s``. Larger is closer to the hard clamp but
+        stiffer near ``x = x_min``. Default ``10.0``.
+
+    Returns
+    -------
+    Float[Array, "..."]
+        Smoothly lower-clamped ``x``.
+    """
+    return x_min + jax.nn.softplus((x - x_min) * sharpness) / sharpness
+
+
+def smooth_max(
+    x: Float[Array, "..."],
+    y: float | Float[Array, "..."],
+    sharpness: float = 10.0,
+) -> Float[Array, "..."]:
+    r"""Smooth approximation of the elementwise ``max(x, y)``.
+
+    The two-argument generalisation of :func:`smooth_clamp`:
+    :math:`y + \mathrm{softplus}\big((x - y)\,s\big) / s`. Symmetric up to the
+    softplus identity ``softplus(z) = z + softplus(-z)``; both gradients are
+    strictly positive logistics, so neither argument's sensitivity is lost.
+
+    Parameters
+    ----------
+    x, y : Float[Array, "..."] or float
+        Inputs (broadcast together).
+    sharpness : float, optional
+        Transition sharpness. Default ``10.0``.
+
+    Returns
+    -------
+    Float[Array, "..."]
+        Smooth elementwise maximum of ``x`` and ``y``.
+    """
+    return y + jax.nn.softplus((x - y) * sharpness) / sharpness

--- a/finitevolx/_src/operators/relaxation.py
+++ b/finitevolx/_src/operators/relaxation.py
@@ -1,0 +1,122 @@
+"""
+Linear drag and Rayleigh-sponge relaxation tendency operators.
+
+Both operators express the same first-order linear-restoring pattern that
+shows up across ocean models as bottom drag, sponge / sponge-layer damping,
+boundary-condition nudging, and tracer restoring:
+
+.. math::
+
+    \\partial_t X \\mathrel{+}= -\\,\\text{coef}\\cdot W \\cdot (X - X_\\text{ref}),
+
+with a spatial weight ``W`` in ``[0, 1]``.  :func:`linear_drag` is the
+``X_ref = 0`` special case applied on a single (bottom) layer; the general
+weighted form is :func:`rayleigh_relaxation`.
+
+Following the finitevolX layering rule (#209), these are mask-free functional
+helpers: spatial selectivity is expressed through the ``weight`` map (for
+relaxation) or the ``layer`` index (for drag), not through a ``Mask2D``.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+
+def linear_drag(
+    u: Float[Array, "..."],
+    v: Float[Array, "..."],
+    *,
+    coef: float | Float[Array, "..."],
+    layer: int = -1,
+) -> tuple[Float[Array, "..."], Float[Array, "..."]]:
+    r"""Rayleigh (linear) bottom-drag tendency :math:`-\text{coef}\cdot u`.
+
+    Returns the drag contribution to the momentum tendency.  For a stacked
+    multi-layer field (layer axis ``-3``, shape ``[..., Nz, Ny, Nx]``) the
+    drag is applied **only** on the selected ``layer`` (the deepest layer by
+    default); every other layer receives an exact zero.  For a single-layer
+    2-D field (shape ``[Ny, Nx]``) the ``layer`` argument is ignored and the
+    drag acts on the whole field.
+
+    Parameters
+    ----------
+    u : Float[Array, "..."]
+        x-velocity at U-points.
+    v : Float[Array, "..."]
+        y-velocity at V-points.
+    coef : float or Float[Array, "..."]
+        Linear drag coefficient ``r`` (units of inverse time).  Scalar or a
+        field broadcastable to the per-layer slice.
+    layer : int, optional
+        Index of the layer the drag acts on along axis ``-3`` (multi-layer
+        inputs only).  Default ``-1`` (deepest layer).
+
+    Returns
+    -------
+    tuple[Float[Array, "..."], Float[Array, "..."]]
+        ``(du, dv)`` drag tendencies, same shapes as ``u`` and ``v``.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> from finitevolx import linear_drag
+    >>> u = jnp.ones((3, 8, 8))  # 3 layers
+    >>> du, dv = linear_drag(u, u, coef=1e-2)
+    >>> bool((du[0] == 0).all()), bool((du[-1] != 0).any())
+    (True, True)
+    """
+    if u.ndim < 3:
+        return -coef * u, -coef * v
+
+    idx = (..., layer, slice(None), slice(None))
+    du = jnp.zeros_like(u).at[idx].set(-coef * u[idx])
+    dv = jnp.zeros_like(v).at[idx].set(-coef * v[idx])
+    return du, dv
+
+
+def rayleigh_relaxation(
+    x: Float[Array, "..."],
+    x_ref: Float[Array, "..."],
+    *,
+    coef: float | Float[Array, "..."],
+    weight: float | Float[Array, "..."],
+) -> Float[Array, "..."]:
+    r"""Sponge / relaxation tendency :math:`-\text{coef}\cdot W\cdot(x - x_\text{ref})`.
+
+    The single linear-restoring operator behind sponge layers, boundary-
+    condition forcing, back-and-forth-nudging (BFN), and tracer restoring.
+    The tendency relaxes ``x`` toward the reference ``x_ref`` at rate ``coef``,
+    modulated by a spatial weight map ``weight`` (typically a smooth ``[0, 1]``
+    taper that is one inside the sponge and zero in the interior).
+
+    Parameters
+    ----------
+    x : Float[Array, "..."]
+        Current field.
+    x_ref : Float[Array, "..."]
+        Reference / target field, broadcastable to ``x``.
+    coef : float or Float[Array, "..."]
+        Relaxation rate ``gamma`` (inverse time).
+    weight : float or Float[Array, "..."]
+        Spatial weight ``W`` in ``[0, 1]``, broadcastable to ``x``.  Use a
+        full-domain ``1.0`` for uniform restoring, or a boundary taper for a
+        sponge layer.
+
+    Returns
+    -------
+    Float[Array, "..."]
+        Relaxation tendency, same shape as ``x``.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> from finitevolx import rayleigh_relaxation
+    >>> ssh = jnp.zeros((8, 8))
+    >>> ssh_bc = jnp.ones((8, 8))
+    >>> dssh = rayleigh_relaxation(ssh, ssh_bc, coef=1e-3, weight=1.0)
+    >>> bool((dssh > 0).all())  # relaxes upward toward ssh_bc
+    True
+    """
+    return -coef * weight * (x - x_ref)

--- a/finitevolx/_src/operators/vorticity.py
+++ b/finitevolx/_src/operators/vorticity.py
@@ -4,6 +4,8 @@ Vorticity and potential-vorticity flux operators on Arakawa C-grids.
 Composes Difference2D and Interpolation2D primitives.
 """
 
+from __future__ import annotations
+
 import equinox as eqx
 import jax.numpy as jnp
 from jaxtyping import Array, Float
@@ -13,6 +15,14 @@ from finitevolx._src.mask import Mask2D, Mask3D
 from finitevolx._src.operators._ghost import interior, zero_z_ghosts
 from finitevolx._src.operators.difference import Difference2D, _curl_2d
 from finitevolx._src.operators.interpolation import Interpolation2D
+from finitevolx._src.operators.stencils import (
+    avg_x_bwd,
+    avg_x_fwd,
+    avg_xbwd_yfwd,
+    avg_xfwd_ybwd,
+    avg_y_bwd,
+    avg_y_fwd,
+)
 
 
 class Vorticity2D(eqx.Module):
@@ -282,3 +292,214 @@ class Vorticity3D(eqx.Module):
         if self.mask is not None:
             out = out * self.mask.xy_corner_strict
         return out
+
+
+def pv_flux_arakawa_lamb(
+    q: Float[Array, "Ny Nx"],
+    u: Float[Array, "Ny Nx"],
+    v: Float[Array, "Ny Nx"],
+    *,
+    alpha: float = 1.0 / 3.0,
+) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
+    """Arakawa--Lamb (1981) PV flux as a grid-free free function.
+
+    Public functional form of :meth:`Vorticity2D.pv_flux_arakawa_lamb` — the
+    energy- and enstrophy-conserving shallow-water vortex-force flux, a
+    weighted blend of the energy-conserving and enstrophy-conserving schemes:
+
+        flux = alpha * energy_conserving + (1 - alpha) * enstrophy_conserving
+
+    The blend at ``alpha = 1/3`` is the Arakawa--Lamb scheme that conserves
+    both total energy and total potential enstrophy.  This free function
+    reproduces the unmasked :class:`Vorticity2D` method bit for bit using only
+    the C-grid averaging stencils, so it is reachable without constructing a
+    grid or instantiating the class (matching the ``divergence_2d`` style).
+    For masked domains, use :class:`Vorticity2D` with a ``mask=``.
+
+    Parameters
+    ----------
+    q : Float[Array, "Ny Nx"]
+        Potential vorticity at X-points (corners), including ghost ring.
+    u : Float[Array, "Ny Nx"]
+        x-velocity (or x mass flux) at U-points.
+    v : Float[Array, "Ny Nx"]
+        y-velocity (or y mass flux) at V-points.
+    alpha : float, optional
+        Blending weight.  Default ``1/3`` (Arakawa--Lamb).
+
+    Returns
+    -------
+    tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]
+        ``(qu, qv)`` — the PV flux at U-points and V-points.
+
+    References
+    ----------
+    Arakawa, A. & Lamb, V. R. (1981). A potential enstrophy and energy
+    conserving scheme for the shallow water equations. *Mon. Wea. Rev.* 109,
+    18--36.
+    """
+    # Energy-conserving: interpolate q and velocity to faces independently.
+    q_on_u = interior(avg_y_bwd(q), q)  # X_to_U
+    q_on_v = interior(avg_x_bwd(q), q)  # X_to_V
+    qu_e = interior(q_on_u[1:-1, 1:-1] * u[1:-1, 1:-1], u)
+    qv_e = interior(q_on_v[1:-1, 1:-1] * v[1:-1, 1:-1], v)
+
+    # Enstrophy-conserving: multiply at corners, then interpolate to faces.
+    u_on_q = interior(avg_y_fwd(u), u)  # U_to_X
+    v_on_q = interior(avg_x_fwd(v), v)  # V_to_X
+    qu_at_q = interior(q[1:-1, 1:-1] * u_on_q[1:-1, 1:-1], q)
+    qv_at_q = interior(q[1:-1, 1:-1] * v_on_q[1:-1, 1:-1], q)
+    qu_s = interior(avg_y_bwd(qu_at_q), qu_at_q)  # X_to_U
+    qv_s = interior(avg_x_bwd(qv_at_q), qv_at_q)  # X_to_V
+
+    qu = alpha * qu_e + (1.0 - alpha) * qu_s
+    qv = alpha * qv_e + (1.0 - alpha) * qv_s
+    return qu, qv
+
+
+# Linear (optimal-polynomial) one-sided reconstruction weights, divided by their
+# common denominator and indexed from the most-upwind cell.  The ``*_POS``
+# stencil is left-biased (used where the advecting velocity is >= 0); ``*_NEG``
+# is right-biased (used where it is < 0).
+_UP3_DENOM = 6.0
+_UP3_POS = (-1.0, 5.0, 2.0)
+_UP3_NEG = (2.0, 5.0, -1.0)
+_UP5_DENOM = 60.0
+_UP5_POS = (2.0, -13.0, 47.0, 27.0, -3.0)
+_UP5_NEG = (-3.0, 27.0, 47.0, -13.0, 2.0)
+
+
+def _upwind_face_bwd_last(
+    omega: Float[Array, "..."],
+    vel: Float[Array, "..."],
+    order: int,
+) -> Float[Array, "..."]:
+    """Upwind-reconstruct ``omega`` to the interior faces along the last axis.
+
+    Faces follow the backward-average stagger: face ``i`` lies between cells
+    ``i-1`` (minus side) and ``i`` (plus side), so the centred limit matches
+    :func:`avg_x_bwd` / :func:`avg_y_bwd`.  The upwind bias is chosen by the
+    sign of ``vel`` at each face.  Returns the ``N - 2`` interior-face values
+    along the last axis (all other axes untouched).  Higher orders fall back
+    to a lower-order stencil on the outer face(s) where the wide stencil does
+    not fit.
+    """
+    v = vel[..., 1:-1]  # advecting velocity at interior faces i = 1 .. N-2
+
+    # Order 1: pure upwind neighbour.
+    f1 = jnp.where(v >= 0.0, omega[..., 0:-2], omega[..., 1:-1])
+    if order == 1:
+        return f1
+
+    n = omega.shape[-1]
+    # 3rd-order stencil valid for faces i = 2 .. N-2 (needs cell i-2 .. i+1).
+    o0, o1, o2, o3 = (
+        omega[..., 0:-3],
+        omega[..., 1:-2],
+        omega[..., 2:-1],
+        omega[..., 3:],
+    )
+    v3 = vel[..., 2:-1]
+    f3_pos = (_UP3_POS[0] * o0 + _UP3_POS[1] * o1 + _UP3_POS[2] * o2) / _UP3_DENOM
+    f3_neg = (_UP3_NEG[0] * o1 + _UP3_NEG[1] * o2 + _UP3_NEG[2] * o3) / _UP3_DENOM
+    f3 = jnp.where(v3 >= 0.0, f3_pos, f3_neg)
+    # Outermost interior face (i = 1) falls back to 1st-order upwind.
+    face3 = jnp.concatenate([f1[..., 0:1], f3], axis=-1)
+    if order == 3 or n < 7:
+        return face3
+
+    # 5th-order stencil valid for faces i = 3 .. N-3 (needs cell i-3 .. i+2).
+    p0, p1, p2, p3, p4, p5 = (
+        omega[..., 0:-5],
+        omega[..., 1:-4],
+        omega[..., 2:-3],
+        omega[..., 3:-2],
+        omega[..., 4:-1],
+        omega[..., 5:],
+    )
+    v5 = vel[..., 3:-2]
+    f5_pos = (
+        _UP5_POS[0] * p0
+        + _UP5_POS[1] * p1
+        + _UP5_POS[2] * p2
+        + _UP5_POS[3] * p3
+        + _UP5_POS[4] * p4
+    ) / _UP5_DENOM
+    f5_neg = (
+        _UP5_NEG[0] * p1
+        + _UP5_NEG[1] * p2
+        + _UP5_NEG[2] * p3
+        + _UP5_NEG[3] * p4
+        + _UP5_NEG[4] * p5
+    ) / _UP5_DENOM
+    f5 = jnp.where(v5 >= 0.0, f5_pos, f5_neg)
+    # The two leading and one trailing interior faces fall back to 3rd order.
+    return jnp.concatenate([face3[..., 0:2], f5, face3[..., -1:]], axis=-1)
+
+
+def vorticity_flux_upwind(
+    omega: Float[Array, "Ny Nx"],
+    U: Float[Array, "Ny Nx"],
+    V: Float[Array, "Ny Nx"],
+    order: int = 3,
+) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
+    r"""Dissipative upwind vortex-force fluxes on a C-grid.
+
+    The MASSH-parity alternative to the energy/enstrophy-conserving schemes
+    (:func:`pv_flux_arakawa_lamb`): instead of averaging, the (absolute)
+    vorticity at corners is reconstructed onto the velocity faces with an
+    order-``{1, 3, 5}`` *upwind* stencil and multiplied by the cross mass
+    flux.  Upwinding makes it monotone and dissipative — a robust, cheap
+    baseline whose adjoint stays well-defined (the bias only kinks where the
+    advecting flux changes sign).
+
+    For the u-momentum equation the flux is the corner vorticity reconstructed
+    in y (advected by the v mass flux ``V`` averaged to U-points) times that
+    flux; for the v-momentum equation it is reconstructed in x (advected by
+    ``U`` averaged to V-points).  The momentum tendencies are then
+    ``dt_u += omega_V`` and ``dt_v -= omega_U`` (caller's responsibility).
+    Mirrors ``MASSH sw.py::_omega_adv_upwind{3,5}``.
+
+    Parameters
+    ----------
+    omega : Float[Array, "Ny Nx"]
+        Absolute vorticity ``zeta + f`` (or PV) at X-points (corners),
+        including ghost ring.
+    U : Float[Array, "Ny Nx"]
+        x mass flux ``h * u`` at U-points.
+    V : Float[Array, "Ny Nx"]
+        y mass flux ``h * v`` at V-points.
+    order : int, optional
+        Upwind stencil width, one of ``{1, 3, 5}``.  Default ``3``.  Near the
+        boundary, where the wide stencil does not fit, it falls back to a
+        lower order.
+
+    Returns
+    -------
+    tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]
+        ``(omega_V, omega_U)`` — the vortex-force flux at U-points (for the
+        u-equation) and V-points (for the v-equation).  Ghost ring is zero.
+
+    Raises
+    ------
+    ValueError
+        If ``order`` is not ``1``, ``3``, or ``5``.
+    """
+    if order not in (1, 3, 5):
+        raise ValueError(f"order must be 1, 3, or 5, got {order!r}")
+
+    # Cross mass flux advecting each velocity face.
+    v_on_u = interior(avg_xfwd_ybwd(V), V)  # V_to_U: north flux at U-points
+    u_on_v = interior(avg_xbwd_yfwd(U), U)  # U_to_V: east flux at V-points
+
+    # omega reconstructed to U-points along y (axis 0): swap y to the last axis.
+    omega_y = jnp.swapaxes(omega, 0, -1)
+    vel_y = jnp.swapaxes(v_on_u, 0, -1)
+    face_y = jnp.swapaxes(_upwind_face_bwd_last(omega_y, vel_y, order), 0, -1)
+    omega_V = interior(face_y[:, 1:-1] * v_on_u[1:-1, 1:-1], omega)
+
+    # omega reconstructed to V-points along x (axis -1, already last).
+    face_x = _upwind_face_bwd_last(omega, u_on_v, order)
+    omega_U = interior(face_x[1:-1, :] * u_on_v[1:-1, 1:-1], omega)
+
+    return omega_V, omega_U

--- a/tests/test_barotropic.py
+++ b/tests/test_barotropic.py
@@ -1,0 +1,149 @@
+"""Tests for the implicit barotropic-mode filter (barotropic_filter).
+
+The variable-coefficient Helmholtz solve is injected, so most tests pin the
+*wiring* (transport sum, RHS scaling, gradient correction) with analytic
+stand-in solvers.  One integration test runs the real multigrid solver.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from finitevolx import barotropic_filter, build_multigrid_solver, divergence_2d
+from finitevolx._src.operators._ghost import interior
+from finitevolx._src.operators.stencils import diff_x_fwd
+
+jax.config.update("jax_enable_x64", True)
+
+
+class TestBarotropicFilterWiring:
+    def test_quiescent_flow_zero_correction(self):
+        u = jnp.zeros((2, 8, 8))
+        h = jnp.ones((2, 8, 8))
+        fu, fv = barotropic_filter(
+            u,
+            u,
+            h,
+            h,
+            dx=1.0,
+            dy=1.0,
+            g=9.81,
+            tau=1.0,
+            dt=1.0,
+            helm_solve=lambda rhs: rhs,
+        )
+        np.testing.assert_allclose(fu, 0.0, atol=1e-12)
+        np.testing.assert_allclose(fv, 0.0, atol=1e-12)
+
+    def test_constant_surface_mode_gives_no_force(self):
+        # A spatially constant w has zero gradient -> zero correction.
+        u = jax.random.normal(jax.random.PRNGKey(0), (2, 8, 8))
+        h = jnp.ones((2, 8, 8))
+        fu, fv = barotropic_filter(
+            u,
+            u,
+            h,
+            h,
+            dx=1.0,
+            dy=1.0,
+            g=2.0,
+            tau=1.0,
+            dt=1.0,
+            helm_solve=lambda rhs: jnp.full_like(rhs, 3.0),
+        )
+        np.testing.assert_allclose(fu, 0.0, atol=1e-12)
+        np.testing.assert_allclose(fv, 0.0, atol=1e-12)
+
+    def test_rhs_is_scaled_transport_divergence(self):
+        u = jax.random.normal(jax.random.PRNGKey(1), (3, 8, 8))
+        v = jax.random.normal(jax.random.PRNGKey(2), (3, 8, 8))
+        hu = jnp.abs(jax.random.normal(jax.random.PRNGKey(3), (3, 8, 8))) + 0.5
+        hv = jnp.abs(jax.random.normal(jax.random.PRNGKey(4), (3, 8, 8))) + 0.5
+        g, tau, dt, dx, dy = 9.81, 0.5, 2.0, 1.5, 1.5
+        captured = {}
+
+        def recorder(rhs):
+            captured["rhs"] = rhs
+            return jnp.zeros_like(rhs)
+
+        barotropic_filter(
+            u, v, hu, hv, dx=dx, dy=dy, g=g, tau=tau, dt=dt, helm_solve=recorder
+        )
+        u_bt = jnp.sum(hu * u, axis=-3)
+        v_bt = jnp.sum(hv * v, axis=-3)
+        expected = divergence_2d(u_bt, v_bt, dx, dy) / (g * tau * dt)
+        np.testing.assert_allclose(captured["rhs"], expected, atol=1e-12)
+
+    def test_correction_is_minus_scaled_gradient(self):
+        u = jnp.zeros((2, 8, 8))
+        h = jnp.ones((2, 8, 8))
+        w = jax.random.normal(jax.random.PRNGKey(5), (8, 8))
+        g, tau, dx = 3.0, 0.7, 1.25
+        fu, _ = barotropic_filter(
+            u,
+            u,
+            h,
+            h,
+            dx=dx,
+            dy=1.0,
+            g=g,
+            tau=tau,
+            dt=1.0,
+            helm_solve=lambda rhs: w,
+        )
+        expected = interior(-g * tau * diff_x_fwd(w) / dx, w)
+        np.testing.assert_allclose(fu, expected, atol=1e-12)
+
+
+class TestBarotropicFilterIntegration:
+    def test_runs_with_real_multigrid_solver(self):
+        Ny = Nx = 16
+        solver = build_multigrid_solver(
+            np.ones((Ny, Nx)), dx=1.0, dy=1.0, coeff=np.ones((Ny, Nx))
+        )
+        key = jax.random.PRNGKey(7)
+        u = jax.random.normal(key, (2, Ny, Nx))
+        v = jax.random.normal(jax.random.PRNGKey(8), (2, Ny, Nx))
+        h = jnp.ones((2, Ny, Nx))
+        fu, fv = barotropic_filter(
+            u,
+            v,
+            h,
+            h,
+            dx=1.0,
+            dy=1.0,
+            g=9.81,
+            tau=1.0,
+            dt=1.0,
+            helm_solve=solver,
+        )
+        assert fu.shape == (Ny, Nx) and fv.shape == (Ny, Nx)
+        assert bool(jnp.isfinite(fu).all()) and bool(jnp.isfinite(fv).all())
+
+    def test_differentiable_through_solver(self):
+        Ny = Nx = 16
+        solver = build_multigrid_solver(
+            np.ones((Ny, Nx)), dx=1.0, dy=1.0, coeff=np.ones((Ny, Nx))
+        )
+        h = jnp.ones((2, Ny, Nx))
+
+        def loss(u):
+            fu, fv = barotropic_filter(
+                u,
+                u,
+                h,
+                h,
+                dx=1.0,
+                dy=1.0,
+                g=9.81,
+                tau=1.0,
+                dt=1.0,
+                helm_solve=solver,
+            )
+            return (fu**2 + fv**2).sum()
+
+        u = jax.random.normal(jax.random.PRNGKey(9), (2, Ny, Nx))
+        grad = jax.grad(loss)(u)
+        assert grad.shape == u.shape and bool(jnp.isfinite(grad).all())

--- a/tests/test_differentiable.py
+++ b/tests/test_differentiable.py
@@ -1,0 +1,81 @@
+"""Tests for the differentiable surrogates (smooth_abs / smooth_clamp / smooth_max).
+
+The whole point of these primitives is a well-defined, nonzero gradient where
+``jnp.abs`` / ``jnp.maximum`` / a hard clamp would have a kink.  The tests
+pin both the forward values (approach the non-smooth function as the knob
+tightens) and the gradient behaviour at the kink.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from finitevolx import smooth_abs, smooth_clamp, smooth_max
+
+jax.config.update("jax_enable_x64", True)
+
+
+class TestSmoothAbs:
+    def test_matches_abs_away_from_origin(self):
+        x = jnp.array([-3.0, -1.0, 0.5, 2.0, 5.0])
+        np.testing.assert_allclose(smooth_abs(x, eps=1e-8), jnp.abs(x), atol=1e-6)
+
+    def test_rounded_at_origin(self):
+        # At x = 0 the value is exactly eps, not 0.
+        assert float(smooth_abs(jnp.array(0.0), eps=1e-3)) == pytest.approx(1e-3)
+
+    def test_gradient_defined_at_zero(self):
+        # jnp.abs has an undefined/zero subgradient at 0; smooth_abs is 0 here
+        # but, crucially, finite (no NaN) — and nonzero just off-centre.
+        g0 = jax.grad(lambda x: smooth_abs(x, eps=1e-3))(0.0)
+        assert jnp.isfinite(g0)
+        assert float(g0) == pytest.approx(0.0, abs=1e-9)
+        g = jax.grad(lambda x: smooth_abs(x, eps=1e-3))(1e-4)
+        assert jnp.isfinite(g) and float(g) != 0.0
+
+    def test_eps_zero_is_hard_abs(self):
+        x = jnp.array([-2.0, 3.0])
+        np.testing.assert_allclose(smooth_abs(x, eps=0.0), jnp.abs(x), atol=0.0)
+
+
+class TestSmoothClamp:
+    def test_above_clamp_is_near_identity(self):
+        x = jnp.array([5.0, 10.0])
+        np.testing.assert_allclose(smooth_clamp(x, 0.0, sharpness=50.0), x, atol=1e-3)
+
+    def test_below_clamp_floors(self):
+        x = jnp.array([-5.0, -10.0])
+        out = smooth_clamp(x, 0.0, sharpness=50.0)
+        np.testing.assert_allclose(out, 0.0, atol=1e-3)
+
+    def test_never_below_min(self):
+        # Never drops below x_min (keeps thickness positive); the softplus
+        # term is >= 0, and strictly positive until it underflows far below
+        # the clamp.
+        x = jnp.linspace(-5.0, 5.0, 21)
+        assert bool((smooth_clamp(x, 1.0) >= 1.0).all())
+        assert bool((smooth_clamp(jnp.array([0.5, 0.9, 1.0]), 1.0) > 1.0).all())
+
+    def test_gradient_positive_everywhere(self):
+        # Unlike maximum(x, x_min) (zero gradient below the clamp), the
+        # gradient is a strictly positive logistic everywhere.
+        grad = jax.vmap(jax.grad(lambda x: smooth_clamp(x, 0.0)))
+        g = grad(jnp.linspace(-5.0, 5.0, 21))
+        assert bool((g > 0.0).all())
+
+
+class TestSmoothMax:
+    def test_matches_maximum(self):
+        x = jnp.array([-2.0, 1.0, 4.0])
+        y = jnp.array([0.0, 0.0, 0.0])
+        np.testing.assert_allclose(
+            smooth_max(x, y, sharpness=50.0), jnp.maximum(x, y), atol=1e-3
+        )
+
+    def test_both_gradients_nonzero(self):
+        # Neither argument's sensitivity is lost at the crossover.
+        gx = jax.grad(lambda x: smooth_max(x, 0.0))(0.0)
+        assert jnp.isfinite(gx) and float(gx) == pytest.approx(0.5, abs=1e-6)

--- a/tests/test_relaxation.py
+++ b/tests/test_relaxation.py
@@ -1,0 +1,65 @@
+"""Tests for the linear-drag and Rayleigh-relaxation tendency operators."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from finitevolx import linear_drag, rayleigh_relaxation
+
+jax.config.update("jax_enable_x64", True)
+
+
+class TestLinearDrag:
+    def test_single_layer_2d(self):
+        u = jnp.ones((8, 8))
+        v = 2.0 * jnp.ones((8, 8))
+        du, dv = linear_drag(u, v, coef=0.1)
+        np.testing.assert_allclose(du, -0.1, atol=1e-12)
+        np.testing.assert_allclose(dv, -0.2, atol=1e-12)
+
+    def test_only_selected_layer_drags(self):
+        u = jnp.ones((3, 8, 8))
+        du, _ = linear_drag(u, u, coef=0.5)
+        assert bool((du[0] == 0).all()) and bool((du[1] == 0).all())
+        np.testing.assert_allclose(du[-1], -0.5, atol=1e-12)
+
+    def test_layer_index_selectable(self):
+        u = jnp.ones((3, 4, 4))
+        du, _ = linear_drag(u, u, coef=1.0, layer=0)
+        np.testing.assert_allclose(du[0], -1.0, atol=1e-12)
+        assert bool((du[1:] == 0).all())
+
+    def test_opposes_velocity(self):
+        u = jnp.array([[2.0, -3.0]])
+        du, _ = linear_drag(u, u, coef=0.25)
+        # drag always points opposite the flow
+        assert bool((jnp.sign(du) == -jnp.sign(u)).all())
+
+
+class TestRayleighRelaxation:
+    def test_restores_toward_reference(self):
+        x = jnp.zeros((6, 6))
+        x_ref = jnp.ones((6, 6))
+        dx = rayleigh_relaxation(x, x_ref, coef=1e-2, weight=1.0)
+        np.testing.assert_allclose(dx, 1e-2, atol=1e-12)
+
+    def test_zero_at_reference(self):
+        x = jnp.full((6, 6), 3.0)
+        dx = rayleigh_relaxation(x, x, coef=0.5, weight=1.0)
+        np.testing.assert_allclose(dx, 0.0, atol=1e-12)
+
+    def test_weight_localises(self):
+        x = jnp.zeros((4, 4))
+        x_ref = jnp.ones((4, 4))
+        weight = jnp.zeros((4, 4)).at[0, :].set(1.0)
+        dx = rayleigh_relaxation(x, x_ref, coef=1.0, weight=weight)
+        assert bool((dx[0] != 0).all()) and bool((dx[1:] == 0).all())
+
+    def test_drag_is_relaxation_to_zero(self):
+        # linear_drag (single layer) is the x_ref = 0 special case.
+        u = jnp.array([[1.0, -2.0, 3.0]])
+        du, _ = linear_drag(u, u, coef=0.3)
+        dx = rayleigh_relaxation(u, jnp.zeros_like(u), coef=0.3, weight=1.0)
+        np.testing.assert_allclose(du, dx, atol=1e-12)

--- a/tests/test_rusanov.py
+++ b/tests/test_rusanov.py
@@ -1,0 +1,68 @@
+"""Tests for the Rusanov / local Lax--Friedrichs flux (rusanov_flux)."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from finitevolx import rusanov_flux
+
+jax.config.update("jax_enable_x64", True)
+
+
+class TestRusanovFlux:
+    def test_shape_drops_one_face(self):
+        q = jnp.ones((6, 7))
+        a = jnp.ones((6, 6))
+        assert rusanov_flux(q, a, axis=-1).shape == (6, 6)
+        a2 = jnp.ones((5, 7))
+        assert rusanov_flux(q, a2, axis=-2).shape == (5, 7)
+
+    def test_constant_scalar_pure_advection(self):
+        # For constant q == c the dissipation term vanishes and F = c * a.
+        c = 3.0
+        q = jnp.full((5, 5), c)
+        a = jnp.linspace(-2.0, 2.0, 4)[None, :] * jnp.ones((5, 1))
+        np.testing.assert_allclose(rusanov_flux(q, a, axis=-1), c * a, atol=1e-12)
+
+    def test_upwind_limit_matches_first_order(self):
+        # F = 0.5 a (qL+qR) - 0.5 |a| (qR-qL) reduces to a*qL (a>0) / a*qR (a<0).
+        q = jnp.array([[1.0, 2.0, 5.0, 11.0]])
+        qL, qR = q[:, :-1], q[:, 1:]
+        a_pos = jnp.full((1, 3), 2.0)
+        np.testing.assert_allclose(
+            rusanov_flux(q, a_pos, axis=-1, eps=0.0), a_pos * qL, atol=1e-12
+        )
+        a_neg = jnp.full((1, 3), -2.0)
+        np.testing.assert_allclose(
+            rusanov_flux(q, a_neg, axis=-1, eps=0.0), a_neg * qR, atol=1e-12
+        )
+
+    def test_dissipation_sign(self):
+        # The flux sits below the pure centred flux when qR > qL and a > 0.
+        q = jnp.array([[1.0, 4.0]])
+        a = jnp.array([[1.0]])
+        centred = 0.5 * a * (q[:, :-1] + q[:, 1:])
+        assert float(rusanov_flux(q, a, axis=-1)[0, 0]) < float(centred[0, 0])
+
+    def test_eps_smoothing_is_small(self):
+        q = jnp.array([[1.0, 4.0]])
+        a = jnp.array([[1.5]])
+        hard = rusanov_flux(q, a, axis=-1, eps=0.0)
+        soft = rusanov_flux(q, a, axis=-1, eps=1e-8)
+        np.testing.assert_allclose(soft, hard, atol=1e-7)
+
+    def test_differentiable_at_zero_velocity(self):
+        # The point of the smooth abs: grad wrt the velocity at a = 0 is finite.
+        q = jnp.array([[1.0, 4.0]])
+        g = jax.grad(lambda s: rusanov_flux(q, jnp.array([[s]]), axis=-1).sum())(0.0)
+        assert jnp.isfinite(g)
+
+    def test_jit_and_grad_compatible(self):
+        q = jax.random.normal(jax.random.PRNGKey(0), (8, 8))
+        a = jax.random.normal(jax.random.PRNGKey(1), (8, 7))
+        flux = jax.jit(lambda q, a: rusanov_flux(q, a, axis=-1))(q, a)
+        assert flux.shape == (8, 7)
+        g = jax.grad(lambda q: rusanov_flux(q, a, axis=-1).sum())(q)
+        assert g.shape == q.shape and bool(jnp.isfinite(g).all())

--- a/tests/test_vorticity_flux.py
+++ b/tests/test_vorticity_flux.py
@@ -1,0 +1,122 @@
+"""Tests for the §2 vorticity-flux additions.
+
+Covers the public ``pv_flux_arakawa_lamb`` free function (parity with the
+``Vorticity2D`` method) and the dissipative ``vorticity_flux_upwind`` operator.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from finitevolx import (
+    CartesianGrid2D,
+    Vorticity2D,
+    pv_flux_arakawa_lamb,
+    vorticity_flux_upwind,
+)
+from finitevolx._src.operators._ghost import interior
+from finitevolx._src.operators.stencils import avg_xfwd_ybwd, avg_y_bwd
+
+jax.config.update("jax_enable_x64", True)
+
+
+@pytest.fixture()
+def grid():
+    return CartesianGrid2D.from_interior(8, 8, 1.0, 1.0)
+
+
+def _rand(seed, shape):
+    return jax.random.normal(jax.random.PRNGKey(seed), shape)
+
+
+class TestPVFluxArakawaLambFreeFn:
+    def test_parity_with_method(self, grid):
+        q = _rand(0, (grid.Ny, grid.Nx))
+        u = _rand(1, (grid.Ny, grid.Nx))
+        v = _rand(2, (grid.Ny, grid.Nx))
+        vort = Vorticity2D(grid=grid)
+        qu_m, qv_m = vort.pv_flux_arakawa_lamb(q, u, v)
+        qu_f, qv_f = pv_flux_arakawa_lamb(q, u, v)
+        np.testing.assert_allclose(qu_f, qu_m, atol=1e-12)
+        np.testing.assert_allclose(qv_f, qv_m, atol=1e-12)
+
+    def test_alpha_endpoints_match_component_schemes(self, grid):
+        q, u, v = (_rand(s, (grid.Ny, grid.Nx)) for s in (3, 4, 5))
+        vort = Vorticity2D(grid=grid)
+        qu_e, qv_e = vort.pv_flux_energy_conserving(q, u, v)
+        qu_s, qv_s = vort.pv_flux_enstrophy_conserving(q, u, v)
+        qu1, qv1 = pv_flux_arakawa_lamb(q, u, v, alpha=1.0)
+        np.testing.assert_allclose(qu1, qu_e, atol=1e-12)
+        np.testing.assert_allclose(qv1, qv_e, atol=1e-12)
+        qu0, qv0 = pv_flux_arakawa_lamb(q, u, v, alpha=0.0)
+        np.testing.assert_allclose(qu0, qu_s, atol=1e-12)
+        np.testing.assert_allclose(qv0, qv_s, atol=1e-12)
+
+    def test_ghost_ring_zero(self, grid):
+        q, u, v = (_rand(s, (grid.Ny, grid.Nx)) for s in (6, 7, 8))
+        qu, _ = pv_flux_arakawa_lamb(q, u, v)
+        assert bool((qu[0] == 0).all()) and bool((qu[-1] == 0).all())
+        assert bool((qu[:, 0] == 0).all()) and bool((qu[:, -1] == 0).all())
+
+
+class TestVorticityFluxUpwind:
+    @pytest.mark.parametrize("order", [1, 3, 5])
+    def test_shapes_and_ghost_ring(self, grid, order):
+        omega = _rand(0, (grid.Ny, grid.Nx))
+        U, V = _rand(1, (grid.Ny, grid.Nx)), _rand(2, (grid.Ny, grid.Nx))
+        oV, oU = vorticity_flux_upwind(omega, U, V, order=order)
+        assert oV.shape == omega.shape and oU.shape == omega.shape
+        assert bool((oV[0] == 0).all()) and bool((oV[:, -1] == 0).all())
+        assert bool((oU[-1] == 0).all()) and bool((oU[:, 0] == 0).all())
+
+    @pytest.mark.parametrize("order", [1, 3, 5])
+    def test_constant_vorticity_is_exact(self, grid, order):
+        # For omega == c the reconstruction is exact: omega_V = c * (V->U flux).
+        c = 2.5
+        omega = jnp.full((grid.Ny, grid.Nx), c)
+        U, V = _rand(3, (grid.Ny, grid.Nx)), _rand(4, (grid.Ny, grid.Nx))
+        v_on_u = interior(avg_xfwd_ybwd(V), V)
+        oV, _ = vorticity_flux_upwind(omega, U, V, order=order)
+        expected = interior(c * v_on_u[1:-1, 1:-1], omega)
+        np.testing.assert_allclose(oV, expected, atol=1e-12)
+
+    def test_linear_field_third_order_exact_interior(self, grid):
+        # A linear vorticity field is reconstructed exactly by the 3rd-order
+        # upwind stencil in the deep interior (away from the order-1 fallback).
+        j = jnp.arange(grid.Ny)[:, None].astype(float)
+        omega = jnp.broadcast_to(0.3 * j + 0.7, (grid.Ny, grid.Nx))  # linear in y
+        U = jnp.zeros((grid.Ny, grid.Nx))
+        V = jnp.ones((grid.Ny, grid.Nx))  # uniform positive advection
+        v_on_u = interior(avg_xfwd_ybwd(V), V)
+        centred = interior(avg_y_bwd(omega), omega)  # exact midpoint for linear
+        expected = interior(centred[1:-1, 1:-1] * v_on_u[1:-1, 1:-1], omega)
+        oV, _ = vorticity_flux_upwind(omega, U, V, order=3)
+        np.testing.assert_allclose(oV[2:-2, 2:-2], expected[2:-2, 2:-2], atol=1e-10)
+
+    def test_upwind_sign_sensitivity(self, grid):
+        # Reversing the advecting flux changes the upwind bias (and the flux).
+        omega = _rand(5, (grid.Ny, grid.Nx))
+        U, V = _rand(6, (grid.Ny, grid.Nx)), _rand(7, (grid.Ny, grid.Nx))
+        oV_p, _ = vorticity_flux_upwind(omega, U, V, order=3)
+        oV_m, _ = vorticity_flux_upwind(omega, U, -V, order=3)
+        # not merely sign-flipped: the stencil itself differs
+        assert not np.allclose(oV_p, -oV_m, atol=1e-8)
+
+    def test_invalid_order_raises(self, grid):
+        omega = jnp.ones((grid.Ny, grid.Nx))
+        with pytest.raises(ValueError, match="order must be"):
+            vorticity_flux_upwind(omega, omega, omega, order=2)
+
+    def test_differentiable(self, grid):
+        omega = _rand(8, (grid.Ny, grid.Nx))
+        U, V = _rand(9, (grid.Ny, grid.Nx)), _rand(10, (grid.Ny, grid.Nx))
+
+        def loss(omega):
+            oV, oU = vorticity_flux_upwind(omega, U, V, order=3)
+            return (oV**2 + oU**2).sum()
+
+        g = jax.grad(loss)(omega)
+        assert g.shape == omega.shape and bool(jnp.isfinite(g).all())

--- a/uv.lock
+++ b/uv.lock
@@ -516,7 +516,7 @@ wheels = [
 
 [[package]]
 name = "finitevolx"
-version = "0.0.41"
+version = "0.0.42"
 source = { editable = "." }
 dependencies = [
     { name = "beartype" },


### PR DESCRIPTION
Adds `docs/design/research/massh_gap_analysis.md` — an operators/primitives gap analysis of finitevolX vs. MASSH (`VarDyn`) — **and now implements the five operators it proposes**, so the doc and the code land together.

The supplied draft was **fact-checked against the local source on `main` (`0.0.42`)** — two exploration passes plus direct API checks. The library turned out to be **further along than the draft assumed**, so several &#34;gaps&#34; were corrected.

## Implementation (commit `71e3fe8`)

All five sections of the note, re-exported flat from the package root and covered by 44 new tests (full suite: 2061 passed; ruff + ty clean):

| § | New public API | Home | Notes |
|---|---|---|---|
| 1 | `rusanov_flux` | `advection/face_flux.py` | local Lax–Friedrichs continuity flux; AD-safe `smooth_abs` wave speed, `eps=0` recovers the hard flux. Tested exact on constant/upwind limits. |
| 2 | `pv_flux_arakawa_lamb`, `vorticity_flux_upwind` | `operators/vorticity.py` | grid-free public wrapper for the existing AL81 flux (**bit-exact parity** with `Vorticity2D.pv_flux_arakawa_lamb`) + the MASSH-parity dissipative order-{1,3,5} upwind vortex-force operator (exact on constant/linear fields). |
| 3 | `barotropic_filter` | `operators/barotropic.py` | implicit external-gravity-wave filter wired over the **existing** variable-coef multigrid (`helm_solve` injected); integration-tested with a real `MultigridSolver`. |
| 4 | `linear_drag`, `rayleigh_relaxation` | `operators/relaxation.py` | linear bottom-drag + sponge/nudging tendency primitives (the latter is the op the companion somax tracer-transport gap needs). |
| 5 | `smooth_abs`, `smooth_clamp`, `smooth_max` | `operators/differentiable.py` | differentiable surrogates with well-defined gradients at the kink. |

Every operator is `jit`/`grad`-safe (tested).

## Doc — major corrections vs. the draft

| Draft claim | Reality (verified) | Fix |
|---|---|---|
| **§2 Arakawa–Lamb (1981) is the headline gap** | **Already implemented** — `Vorticity2D.pv_flux_arakawa_lamb` (`operators/vorticity.py:202`) **and** `MomentumAdvection2D`. Both public. | Narrowed §2 to the genuinely-missing pieces: the *dissipative upwind* vorticity flux + a public free-function wrapper for AL81 (both now shipped). |
| Examples use `fvx.operators.X` / `fvx.advection.X` | API is **flat** — those namespaces don&#39;t exist | Rewrote every example to the flat form. |
| §3 needs a variable-coef Helmholtz solve we lack | **Already exists** — `build_multigrid_solver(coeff=...)` | Reframed §3 as a **thin operator over the existing solver** (now built). |

## Notes

- §0 &#34;Not a gap&#34; table carries **verified `file:line`** for every claimed-present capability.
- MASSH `file:line` citations are left as **unverified pointers** (upstream not re-checked); flagged in a provenance admonition.
- `uv.lock`&#39;s incidental `0.0.41→0.0.42` sync bump is intentionally left out of these commits.

https://claude.ai/code/session_01Gi9jLHHnRbn7vMUmXAe3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi9jLHHnRbn7vMUmXAe3Cr)_