### PR TITLE
feat(operators): opt-in "open" lateral-wall mode for advection & diffusion (#234)

### DIFF
--- a/finitevolx/_src/advection/advection.py
+++ b/finitevolx/_src/advection/advection.py
@@ -80,9 +80,30 @@ def _wall_upwind_flux(
 
     ``q_lo`` is the cell on the low-index side of the face (the upwind cell
     when ``vel_wall >= 0``) and ``q_hi`` the high-index side.  Matches the
-    ``u >= 0`` convention used by the reconstruction primitives, and reads
-    the caller-filled ghost cell on the outward side so that Dirichlet /
-    outflow / periodic boundary values enter the wall-face flux.
+    ``u >= 0`` convention used by the reconstruction primitives.
+
+    Ghost-cell contract for ``wall="open"``
+    ---------------------------------------
+    On an inflow wall the flux carries the ghost cell **as-is**, i.e. the
+    ghost is interpreted as the *exterior cell-centred* tracer value.  This is
+    exact for:
+
+    * **periodic** — the ghost is the opposite interior cell, so the seam
+      flux uses the wrapped upwind cell (and the paired walls net to zero,
+      conserving mass); and
+    * **outflow** — zero-gradient, the interior cell is used regardless.
+
+    For a **Dirichlet inflow** wall the ghost must therefore hold the boundary
+    concentration *as a cell value* (``ghost = value``).  Note that
+    :class:`~finitevolx.Dirichlet1D` instead writes the *face* reflection
+    ``2*value - interior`` (chosen so a centred stencil sees ``value`` at the
+    face — the right convention for :class:`~finitevolx.Diffusion2D`).  Pairing
+    that atom with open-mode advection makes the inflow carry
+    ``2*value - interior`` rather than ``value``; fill the ghost with the
+    plain boundary value when an exact advective Dirichlet inflow is required.
+    A single BC-agnostic wall flux cannot satisfy both the periodic and the
+    face-Dirichlet conventions at once, so this is resolved by the ghost fill,
+    not the operator.
     """
     return jnp.where(vel_wall >= 0.0, q_lo, q_hi) * vel_wall
 

--- a/finitevolx/_src/advection/advection.py
+++ b/finitevolx/_src/advection/advection.py
@@ -54,6 +54,38 @@ _MASK_DISPATCHABLE_3D = _MASK_DISPATCHABLE
 # requested one at dispatch time.
 _HIERARCHY_SIZES: tuple[int, ...] = (2, 4, 6)
 
+# Supported lateral-wall treatments (see the ``wall`` argument on the
+# advection operators).
+_WALL_MODES = frozenset({"closed", "open"})
+
+
+def _validate_wall(wall: str, mask: object) -> None:
+    """Validate the ``wall`` argument and reject unsupported combinations."""
+    if wall not in _WALL_MODES:
+        raise ValueError(f"wall must be one of {sorted(_WALL_MODES)!r}; got {wall!r}")
+    if wall == "open" and mask is not None:
+        raise NotImplementedError(
+            "wall='open' is not supported together with a mask; the open-wall "
+            "ghost-flux path assumes a rectangular domain with no interior "
+            "land. Use wall='closed' with the mask, or drop the mask."
+        )
+
+
+def _wall_upwind_flux(
+    vel_wall: Float[Array, "..."],
+    q_lo: Float[Array, "..."],
+    q_hi: Float[Array, "..."],
+) -> Float[Array, "..."]:
+    """First-order upwind flux at a single domain-wall face.
+
+    ``q_lo`` is the cell on the low-index side of the face (the upwind cell
+    when ``vel_wall >= 0``) and ``q_hi`` the high-index side.  Matches the
+    ``u >= 0`` convention used by the reconstruction primitives, and reads
+    the caller-filled ghost cell on the outward side so that Dirichlet /
+    outflow / periodic boundary values enter the wall-face flux.
+    """
+    return jnp.where(vel_wall >= 0.0, q_lo, q_hi) * vel_wall
+
 
 def _rec_funcs_for_method_1d(
     recon: Reconstruction1D, method: str
@@ -219,6 +251,7 @@ class Advection1D(eqx.Module):
         h: Float[Array, "Nx"],
         u: Float[Array, "Nx"],
         method: str = "upwind1",
+        wall: str = "closed",
     ) -> Float[Array, "Nx"]:
         """Advective tendency -d(h*u)/dx at T-points.
 
@@ -235,12 +268,25 @@ class Advection1D(eqx.Module):
             ``'upwind3'``, ``'weno3'``, ``'weno5'``, ``'weno7'``, ``'weno9'``,
             or a flux-limiter TVD scheme: ``'minmod'``, ``'van_leer'``,
             ``'superbee'``, ``'mc'``.
+        wall : {"closed", "open"}, default "closed"
+            Lateral-boundary treatment.  ``"closed"`` (default, unchanged)
+            writes the tendency only on the strict interior ``[2:-2]`` and
+            treats the domain walls as no-flux — the wall-adjacent interior
+            cells hold stale values.  ``"open"`` writes the full interior
+            ``[1:-1]`` and computes the two domain-wall face fluxes with a
+            first-order upwind reconstruction that reads the ghost ring, so
+            Dirichlet / outflow / periodic boundaries (applied by the caller
+            to the ghost cells beforehand) drive the advective transport.
+            The interior faces keep the requested high-order ``method``; the
+            flux field stays single-valued, so mass is conserved exactly.
+            ``"open"`` is not supported together with a ``mask``.
 
         Returns
         -------
         Float[Array, "Nx"]
             Advective tendency at T-points.
         """
+        _validate_wall(wall, self.mask)
         # ── masked path: route through upwind_flux with adaptive stencils ─
         if self._mask_hierarchy_x is not None and method in _MASK_DISPATCHABLE:
             rfx, sizes = _rec_funcs_for_method_1d(self.recon, method)
@@ -272,9 +318,17 @@ class Advection1D(eqx.Module):
         # dh[i] = -(fe[i+1/2] - fe[i-1/2]) / dx
         # fe[i] represents the flux at the east face of cell i (at i+1/2)
         # For cell i, we need fe[i] (east) and fe[i-1] (west)
-        # Only use face fluxes that are defined by the reconstruction scheme,
-        # avoiding the ghost-ring entries fe[0] and fe[-1].
-        out = out.at[2:-2].set(-(fe[2:-2] - fe[1:-3]) / self.grid.dx)
+        if wall == "open":
+            # Overwrite the two domain-wall faces (west face 1/2 == fe[0],
+            # east face Nx-3/2 == fe[-2]) with a first-order upwind flux that
+            # reads the ghost ring, then write the full interior [1:-1].
+            fe = fe.at[0].set(_wall_upwind_flux(u[0], h[0], h[1]))
+            fe = fe.at[-2].set(_wall_upwind_flux(u[-2], h[-2], h[-1]))
+            out = out.at[1:-1].set(-(fe[1:-1] - fe[0:-2]) / self.grid.dx)
+        else:
+            # Only use face fluxes that are defined by the reconstruction
+            # scheme, avoiding the ghost-ring entries fe[0] and fe[-1].
+            out = out.at[2:-2].set(-(fe[2:-2] - fe[1:-3]) / self.grid.dx)
         if self.mask is not None:
             out = out * self.mask.h
         return out
@@ -332,6 +386,7 @@ class Advection2D(eqx.Module):
         u: Float[Array, "Ny Nx"],
         v: Float[Array, "Ny Nx"],
         method: str = "upwind1",
+        wall: str = "closed",
     ) -> Float[Array, "Ny Nx"]:
         """Advective tendency -div(h * u_vec) at T-points.
 
@@ -351,12 +406,25 @@ class Advection2D(eqx.Module):
             ``'upwind3'``, ``'weno3'``, ``'weno5'``, ``'weno7'``, ``'weno9'``,
             ``'wenoz5'``, or a flux-limiter TVD scheme: ``'minmod'``,
             ``'van_leer'``, ``'superbee'``, ``'mc'``.
+        wall : {"closed", "open"}, default "closed"
+            Lateral-boundary treatment.  ``"closed"`` (default, unchanged)
+            writes the tendency only on the strict interior ``[2:-2, 2:-2]``
+            and treats all four domain walls as no-flux.  ``"open"`` writes
+            the full interior ``[1:-1, 1:-1]`` and computes the four
+            domain-wall face fluxes with a first-order upwind reconstruction
+            that reads the ghost ring, so Dirichlet / outflow / periodic
+            lateral boundaries (applied by the caller to the ghost cells
+            beforehand) drive horizontal transport.  Interior faces keep the
+            requested high-order ``method`` and the flux field stays
+            single-valued, so mass is conserved exactly.  ``"open"`` is not
+            supported together with a ``mask``.
 
         Returns
         -------
         Float[Array, "Ny Nx"]
             Advective tendency at T-points.
         """
+        _validate_wall(wall, self.mask)
         # ── masked path: route through upwind_flux with pre-built hier. ──
         mh_x = self._mask_hierarchy_x
         mh_y = self._mask_hierarchy_y
@@ -405,16 +473,32 @@ class Advection2D(eqx.Module):
         # fe[j,i] is flux at east face of cell [j,i], fn[j,i] is flux at north face
         # For cell [j,i], we need fe[j,i] (east) and fe[j,i-1] (west),
         #                      and fn[j,i] (north) and fn[j-1,i] (south)
-        # Only use face fluxes that are defined by the reconstruction scheme,
-        # avoiding ghost-ring flux entries.
-        out = interior(
-            -(
-                (fe[2:-2, 2:-2] - fe[2:-2, 1:-3]) / self.grid.dx
-                + (fn[2:-2, 2:-2] - fn[1:-3, 2:-2]) / self.grid.dy
-            ),
-            h,
-            ghost=2,
-        )
+        if wall == "open":
+            # Overwrite the west/east (fe cols 0, -2) and south/north
+            # (fn rows 0, -2) domain-wall faces with a first-order upwind
+            # flux that reads the ghost ring, then write the full interior.
+            fe = fe.at[:, 0].set(_wall_upwind_flux(u[:, 0], h[:, 0], h[:, 1]))
+            fe = fe.at[:, -2].set(_wall_upwind_flux(u[:, -2], h[:, -2], h[:, -1]))
+            fn = fn.at[0, :].set(_wall_upwind_flux(v[0, :], h[0, :], h[1, :]))
+            fn = fn.at[-2, :].set(_wall_upwind_flux(v[-2, :], h[-2, :], h[-1, :]))
+            out = jnp.zeros_like(h)
+            out = out.at[1:-1, 1:-1].set(
+                -(
+                    (fe[1:-1, 1:-1] - fe[1:-1, 0:-2]) / self.grid.dx
+                    + (fn[1:-1, 1:-1] - fn[0:-2, 1:-1]) / self.grid.dy
+                )
+            )
+        else:
+            # Only use face fluxes defined by the reconstruction scheme,
+            # avoiding ghost-ring flux entries.
+            out = interior(
+                -(
+                    (fe[2:-2, 2:-2] - fe[2:-2, 1:-3]) / self.grid.dx
+                    + (fn[2:-2, 2:-2] - fn[1:-3, 2:-2]) / self.grid.dy
+                ),
+                h,
+                ghost=2,
+            )
         if self.mask is not None:
             out = out * self.mask.h
         return out
@@ -475,6 +559,7 @@ class Advection3D(eqx.Module):
         u: Float[Array, "Nz Ny Nx"],
         v: Float[Array, "Nz Ny Nx"],
         method: str = "upwind1",
+        wall: str = "closed",
     ) -> Float[Array, "Nz Ny Nx"]:
         """Advective tendency -div(h * u_vec) at T-points over all z-levels.
 
@@ -490,12 +575,27 @@ class Advection3D(eqx.Module):
             Reconstruction method: ``'naive'``, ``'upwind1'``, ``'weno3'``,
             ``'weno5'``, ``'weno7'``, ``'weno9'``, or a flux-limiter TVD
             scheme: ``'minmod'``, ``'van_leer'``, ``'superbee'``, ``'mc'``.
+        wall : {"closed", "open"}, default "closed"
+            Lateral-boundary treatment for the horizontal plane.
+            ``"closed"`` (default, unchanged) writes the horizontal tendency
+            only on the strict interior ``[1:-1, 2:-2, 2:-2]`` and treats the
+            four lateral walls as no-flux — the wall-adjacent interior ring
+            holds stale values.  ``"open"`` writes the full interior
+            ``[1:-1, 1:-1, 1:-1]`` and computes the lateral domain-wall face
+            fluxes with a first-order upwind reconstruction that reads the
+            ghost ring, so Dirichlet / outflow / periodic lateral boundaries
+            (applied by the caller to the ghost cells beforehand) drive
+            horizontal transport.  Interior faces keep the requested
+            high-order ``method`` and the flux field stays single-valued, so
+            mass is conserved exactly.  The z axis is a batch dimension and is
+            unaffected.  ``"open"`` is not supported together with a ``mask``.
 
         Returns
         -------
         Float[Array, "Nz Ny Nx"]
             Advective tendency at T-points.
         """
+        _validate_wall(wall, self.mask)
         # ── masked path: route through upwind_flux with pre-built 3-D hier. ──
         mh_x = self._mask_hierarchy_x
         mh_y = self._mask_hierarchy_y
@@ -534,17 +634,41 @@ class Advection3D(eqx.Module):
         out = jnp.zeros_like(h)
         # dh[k, j, i] = -( (fe[k,j,i+1/2] - fe[k,j,i-1/2])/dx
         #                 + (fn[k,j+1/2,i] - fn[k,j-1/2,i])/dy )
-        # Reconstruction writes to [1:-1, 1:-1, 1:-1]; the west flux at i=0
-        # and south flux at j=0 are ghost cells (value 0, not filled).
-        # Consistent with 1D/2D operators, skip the ghost-adjacent interior
-        # ring in the horizontal plane so we never read ghost flux cells.
-        # All z-levels are independent, so z uses the full interior [1:-1].
-        out = out.at[1:-1, 2:-2, 2:-2].set(
-            -(
-                (fe[1:-1, 2:-2, 2:-2] - fe[1:-1, 2:-2, 1:-3]) / self.grid.dx
-                + (fn[1:-1, 2:-2, 2:-2] - fn[1:-1, 1:-3, 2:-2]) / self.grid.dy
+        if wall == "open":
+            # Overwrite the west/east (fe cols 0, -2) and south/north
+            # (fn rows 0, -2) lateral wall faces with a first-order upwind
+            # flux that reads the ghost ring, then write the full horizontal
+            # interior.  z is a batch dimension and keeps the full [1:-1].
+            fe = fe.at[:, :, 0].set(
+                _wall_upwind_flux(u[:, :, 0], h[:, :, 0], h[:, :, 1])
             )
-        )
+            fe = fe.at[:, :, -2].set(
+                _wall_upwind_flux(u[:, :, -2], h[:, :, -2], h[:, :, -1])
+            )
+            fn = fn.at[:, 0, :].set(
+                _wall_upwind_flux(v[:, 0, :], h[:, 0, :], h[:, 1, :])
+            )
+            fn = fn.at[:, -2, :].set(
+                _wall_upwind_flux(v[:, -2, :], h[:, -2, :], h[:, -1, :])
+            )
+            out = out.at[1:-1, 1:-1, 1:-1].set(
+                -(
+                    (fe[1:-1, 1:-1, 1:-1] - fe[1:-1, 1:-1, 0:-2]) / self.grid.dx
+                    + (fn[1:-1, 1:-1, 1:-1] - fn[1:-1, 0:-2, 1:-1]) / self.grid.dy
+                )
+            )
+        else:
+            # Reconstruction writes to [1:-1, 1:-1, 1:-1]; the west flux at i=0
+            # and south flux at j=0 are ghost cells (value 0, not filled).
+            # Consistent with 1D/2D operators, skip the ghost-adjacent interior
+            # ring in the horizontal plane so we never read ghost flux cells.
+            # All z-levels are independent, so z uses the full interior [1:-1].
+            out = out.at[1:-1, 2:-2, 2:-2].set(
+                -(
+                    (fe[1:-1, 2:-2, 2:-2] - fe[1:-1, 2:-2, 1:-3]) / self.grid.dx
+                    + (fn[1:-1, 2:-2, 2:-2] - fn[1:-1, 1:-3, 2:-2]) / self.grid.dy
+                )
+            )
         if self.mask is not None:
             out = out * self.mask.h
         return out

--- a/finitevolx/_src/diffusion/diffusion.py
+++ b/finitevolx/_src/diffusion/diffusion.py
@@ -25,17 +25,30 @@ Step 3 – Tendency at T-points (backward diff of fluxes, U → T and V → T):
 
 Boundary conditions
 -------------------
-Face fluxes at domain walls are zero by construction:
+By default (``wall="closed"``) face fluxes at domain walls are zero by
+construction:
 
 * West boundary face (U-point col 0) is never written — stays zero.
 * East boundary face (U-point col Nx-2) is not computed — stays zero.
 * South boundary face (V-point row 0) is never written — stays zero.
 * North boundary face (V-point row Ny-2) is not computed — stays zero.
 
-This gives no-flux (closed-wall) BCs at all four domain walls by default.
-Custom boundary conditions must be imposed via the tracer field ``h``, the
-diffusivity ``kappa``, or by providing a ``Mask2D`` / ``Mask3D`` to the
-class operator.
+This gives no-flux (closed-wall) BCs at all four domain walls — the correct
+convention for a closed / land-masked basin.  The ghost ring has no effect on
+the horizontal diffusion term in this mode.
+
+The class operators :class:`Diffusion2D` / :class:`Diffusion3D` also accept
+``wall="open"``, which additionally assembles the wall-face fluxes
+``κ·(h_edge − h_ghost)/dx`` from the caller-filled ghost ring.  A lateral
+Dirichlet / periodic boundary applied to the ghost cells (e.g. via
+:class:`~finitevolx.BoundaryConditionSet`) then produces a diffusive flux
+through the wall.  The flux field stays single-valued, so the tendency is
+exactly flux-conservative.  ``wall="open"`` is not supported together with a
+mask.
+
+Custom closed-wall boundary conditions can also be imposed via the tracer
+field ``h``, the diffusivity ``kappa``, or by providing a ``Mask2D`` /
+``Mask3D`` to the class operator.
 
 Masking
 -------
@@ -65,6 +78,18 @@ from jaxtyping import Array, Bool, Float
 from finitevolx._src.grid.cartesian import CartesianGrid2D, CartesianGrid3D
 from finitevolx._src.mask import Mask2D, Mask3D
 from finitevolx._src.operators._ghost import interior, zero_z_ghosts
+
+
+def _check_diffusion_wall(wall: str, mask: object) -> None:
+    """Validate the ``wall`` argument and reject unsupported combinations."""
+    if wall not in ("closed", "open"):
+        raise ValueError(f"wall must be 'closed' or 'open'; got {wall!r}")
+    if wall == "open" and mask is not None:
+        raise NotImplementedError(
+            "wall='open' is not supported together with a mask; the open-wall "
+            "ghost-flux path assumes a rectangular domain with no interior "
+            "land. Use wall='closed' with the mask, or drop the mask."
+        )
 
 
 def diffusion_2d(
@@ -125,6 +150,7 @@ def _diffusion_2d_impl(
     mh: Bool[Array, "Ny Nx"] | Float[Array, "Ny Nx"] | None,
     mu: Bool[Array, "Ny Nx"] | Float[Array, "Ny Nx"] | None,
     mv: Bool[Array, "Ny Nx"] | Float[Array, "Ny Nx"] | None,
+    wall: str = "closed",
 ) -> Float[Array, "Ny Nx"]:
     """Shared 2-D diffusion kernel with explicit raw-array masks.
 
@@ -133,35 +159,10 @@ def _diffusion_2d_impl(
     raw bool / float arrays).  The three-step intermediate-flux masking
     pattern (see module docstring) is inlined here so vmap can also
     use it per-z-slice from ``Diffusion3D``.
+
+    ``wall`` selects the domain-wall face treatment (see :class:`Diffusion2D`).
     """
-    # Prepare kappa slices for each face direction.
-    # When kappa is a full [Ny, Nx] array, use the western/southern source
-    # T-cell value for each face:
-    #   flux_x at (j, i+½) uses κ[j, i] → slice kappa_arr[1:-1, 1:-2]
-    #   flux_y at (j+½, i) uses κ[j, i] → slice kappa_arr[1:-2, 1:-1]
-    kappa_arr = jnp.asarray(kappa)
-    if kappa_arr.ndim >= 2:
-        kappa_x = kappa_arr[1:-1, 1:-2]  # (Ny-2, Nx-3) — source T-cell for east faces
-        kappa_y = kappa_arr[1:-2, 1:-1]  # (Ny-3, Nx-2) — source T-cell for north faces
-    else:
-        kappa_x = kappa_arr
-        kappa_y = kappa_arr
-
-    # Step 1: East-face flux at U-points
-    # flux_x[j, i+1/2] = κ * (h[j, i+1] - h[j, i]) / dx
-    # Written for i = 1 ... Nx-3 only; east boundary face (i=Nx-2) stays 0.
-    flux_x = jnp.zeros_like(h)
-    flux_x = flux_x.at[1:-1, 1:-2].set(kappa_x * (h[1:-1, 2:-1] - h[1:-1, 1:-2]) / dx)
-    if mu is not None:
-        flux_x = flux_x * mu
-
-    # Step 2: North-face flux at V-points
-    # flux_y[j+1/2, i] = κ * (h[j+1, i] - h[j, i]) / dy
-    # Written for j = 1 ... Ny-3 only; north boundary face (j=Ny-2) stays 0.
-    flux_y = jnp.zeros_like(h)
-    flux_y = flux_y.at[1:-2, 1:-1].set(kappa_y * (h[2:-1, 1:-1] - h[1:-2, 1:-1]) / dy)
-    if mv is not None:
-        flux_y = flux_y * mv
+    flux_x, flux_y = _diffusion_2d_fluxes_impl(h, kappa, dx, dy, mu, mv, wall=wall)
 
     # Step 3: Tendency at T-points (divergence of flux)
     # dh[j, i] = (flux_x[j, i+1/2] - flux_x[j, i-1/2]) / dx
@@ -183,23 +184,45 @@ def _diffusion_2d_fluxes_impl(
     dy: float,
     mu: Bool[Array, "Ny Nx"] | Float[Array, "Ny Nx"] | None,
     mv: Bool[Array, "Ny Nx"] | Float[Array, "Ny Nx"] | None,
+    wall: str = "closed",
 ) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
-    """Shared 2-D diagnostic-flux kernel with explicit raw-array masks."""
+    """Shared 2-D diagnostic-flux kernel with explicit raw-array masks.
+
+    ``wall`` selects the domain-wall face treatment (see :class:`Diffusion2D`).
+    ``"closed"`` (default) leaves the four wall faces at zero (no-flux);
+    ``"open"`` also writes the wall faces as ``κ·(h_edge − h_ghost)/dx`` from
+    the caller-filled ghost ring so lateral Dirichlet / periodic boundaries
+    produce a diffusive flux through the wall.
+    """
+    if wall not in ("closed", "open"):
+        raise ValueError(f"wall must be 'closed' or 'open'; got {wall!r}")
     kappa_arr = jnp.asarray(kappa)
-    if kappa_arr.ndim >= 2:
-        kappa_x = kappa_arr[1:-1, 1:-2]
-        kappa_y = kappa_arr[1:-2, 1:-1]
-    else:
-        kappa_x = kappa_arr
-        kappa_y = kappa_arr
 
     flux_x = jnp.zeros_like(h)
-    flux_x = flux_x.at[1:-1, 1:-2].set(kappa_x * (h[1:-1, 2:-1] - h[1:-1, 1:-2]) / dx)
+    flux_y = jnp.zeros_like(h)
+
+    if wall == "open":
+        # East-face flux at ALL faces i = 0 ... Nx-2, including the west
+        # (i=0) and east (i=Nx-2) domain-wall faces, reading the ghost ring.
+        kappa_x = kappa_arr[1:-1, :-1] if kappa_arr.ndim >= 2 else kappa_arr
+        kappa_y = kappa_arr[:-1, 1:-1] if kappa_arr.ndim >= 2 else kappa_arr
+        flux_x = flux_x.at[1:-1, :-1].set(kappa_x * (h[1:-1, 1:] - h[1:-1, :-1]) / dx)
+        flux_y = flux_y.at[:-1, 1:-1].set(kappa_y * (h[1:, 1:-1] - h[:-1, 1:-1]) / dy)
+    else:
+        # Interior faces only; wall faces stay 0 → no-flux (closed) walls.
+        #   flux_x at (j, i+½) uses κ[j, i] → slice kappa_arr[1:-1, 1:-2]
+        #   flux_y at (j+½, i) uses κ[j, i] → slice kappa_arr[1:-2, 1:-1]
+        kappa_x = kappa_arr[1:-1, 1:-2] if kappa_arr.ndim >= 2 else kappa_arr
+        kappa_y = kappa_arr[1:-2, 1:-1] if kappa_arr.ndim >= 2 else kappa_arr
+        flux_x = flux_x.at[1:-1, 1:-2].set(
+            kappa_x * (h[1:-1, 2:-1] - h[1:-1, 1:-2]) / dx
+        )
+        flux_y = flux_y.at[1:-2, 1:-1].set(
+            kappa_y * (h[2:-1, 1:-1] - h[1:-2, 1:-1]) / dy
+        )
+
     if mu is not None:
         flux_x = flux_x * mu
-
-    flux_y = jnp.zeros_like(h)
-    flux_y = flux_y.at[1:-2, 1:-1].set(kappa_y * (h[2:-1, 1:-1] - h[1:-2, 1:-1]) / dy)
     if mv is not None:
         flux_y = flux_y * mv
 
@@ -249,6 +272,7 @@ class Diffusion2D(eqx.Module):
         self,
         h: Float[Array, "Ny Nx"],
         kappa: float | Float[Array, "Ny Nx"],
+        wall: str = "closed",
     ) -> Float[Array, "Ny Nx"]:
         """Diffusion tendency ∂h/∂t = ∇·(κ ∇h) at T-points.
 
@@ -265,6 +289,16 @@ class Diffusion2D(eqx.Module):
             Tracer field at T-points.
         kappa : float or Float[Array, "Ny Nx"]
             Diffusion coefficient (scalar or T-point field).
+        wall : {"closed", "open"}, default "closed"
+            Domain-wall face treatment.  ``"closed"`` (default, unchanged)
+            leaves the four wall faces at zero, giving no-flux (closed-wall)
+            BCs — the ghost ring has no effect on the horizontal diffusion
+            term.  ``"open"`` also assembles the wall-face fluxes
+            ``κ·(h_edge − h_ghost)/dx`` from the caller-filled ghost ring, so
+            lateral Dirichlet / periodic boundaries produce a diffusive flux
+            through the wall.  The flux field stays single-valued, so the
+            tendency is exactly flux-conservative.  ``"open"`` is not
+            supported together with a ``mask``.
 
         Returns
         -------
@@ -273,9 +307,17 @@ class Diffusion2D(eqx.Module):
             the intermediate-flux masking pattern described in the
             class docstring is applied.
         """
+        _check_diffusion_wall(wall, self.mask)
         if self.mask is None:
             return _diffusion_2d_impl(
-                h, kappa, self.grid.dx, self.grid.dy, mh=None, mu=None, mv=None
+                h,
+                kappa,
+                self.grid.dx,
+                self.grid.dy,
+                mh=None,
+                mu=None,
+                mv=None,
+                wall=wall,
             )
         return _diffusion_2d_impl(
             h,
@@ -285,12 +327,14 @@ class Diffusion2D(eqx.Module):
             mh=self.mask.h,
             mu=self.mask.u,
             mv=self.mask.v,
+            wall=wall,
         )
 
     def fluxes(
         self,
         h: Float[Array, "Ny Nx"],
         kappa: float | Float[Array, "Ny Nx"],
+        wall: str = "closed",
     ) -> tuple[Float[Array, "Ny Nx"], Float[Array, "Ny Nx"]]:
         """Diagnostic diffusive face fluxes at U- and V-points.
 
@@ -307,6 +351,10 @@ class Diffusion2D(eqx.Module):
             Tracer field at T-points.
         kappa : float or Float[Array, "Ny Nx"]
             Diffusion coefficient (scalar or T-point field).
+        wall : {"closed", "open"}, default "closed"
+            Domain-wall face treatment (see :meth:`__call__`).  ``"closed"``
+            leaves wall faces at zero; ``"open"`` also fills them from the
+            ghost ring.  ``"open"`` is not supported together with a ``mask``.
 
         Returns
         -------
@@ -316,9 +364,10 @@ class Diffusion2D(eqx.Module):
             ``flux_x`` is multiplied by ``mask.u`` and ``flux_y`` by
             ``mask.v``.
         """
+        _check_diffusion_wall(wall, self.mask)
         if self.mask is None:
             return _diffusion_2d_fluxes_impl(
-                h, kappa, self.grid.dx, self.grid.dy, mu=None, mv=None
+                h, kappa, self.grid.dx, self.grid.dy, mu=None, mv=None, wall=wall
             )
         return _diffusion_2d_fluxes_impl(
             h,
@@ -327,6 +376,7 @@ class Diffusion2D(eqx.Module):
             self.grid.dy,
             mu=self.mask.u,
             mv=self.mask.v,
+            wall=wall,
         )
 
 
@@ -366,6 +416,7 @@ class Diffusion3D(eqx.Module):
         self,
         h: Float[Array, "Nz Ny Nx"],
         kappa: float | Float[Array, "Nz Ny Nx"],
+        wall: str = "closed",
     ) -> Float[Array, "Nz Ny Nx"]:
         """Diffusion tendency ∂h/∂t = ∇·(κ ∇h) at T-points over all z-levels.
 
@@ -379,6 +430,13 @@ class Diffusion3D(eqx.Module):
             Tracer field at T-points.
         kappa : float or Float[Array, "Nz Ny Nx"]
             Diffusion coefficient (scalar or T-point field).
+        wall : {"closed", "open"}, default "closed"
+            Lateral domain-wall face treatment, applied identically at every
+            z-level (see :class:`Diffusion2D`).  ``"closed"`` (default,
+            unchanged) gives no-flux lateral walls; ``"open"`` assembles the
+            lateral wall-face fluxes from the caller-filled ghost ring so
+            Dirichlet / periodic lateral boundaries drive horizontal
+            diffusion.  ``"open"`` is not supported together with a ``mask``.
 
         Returns
         -------
@@ -386,6 +444,7 @@ class Diffusion3D(eqx.Module):
             Diffusion tendency at T-points.  When ``self.mask`` is set,
             the intermediate-flux masking pattern is applied per-z-slice.
         """
+        _check_diffusion_wall(wall, self.mask)
         dx, dy = self.grid.dx, self.grid.dy
         kappa_arr = jnp.asarray(kappa)
         kappa_ax = 0 if kappa_arr.ndim >= 3 else None
@@ -393,7 +452,9 @@ class Diffusion3D(eqx.Module):
         if self.mask is None:
             # Unmasked path: vmap the free function over z-levels.
             def _apply_unmasked(h_k, kap_k):
-                return _diffusion_2d_impl(h_k, kap_k, dx, dy, mh=None, mu=None, mv=None)
+                return _diffusion_2d_impl(
+                    h_k, kap_k, dx, dy, mh=None, mu=None, mv=None, wall=wall
+                )
 
             out = eqx.filter_vmap(_apply_unmasked, in_axes=(0, kappa_ax))(h, kappa_arr)
             return zero_z_ghosts(out)
@@ -415,6 +476,7 @@ class Diffusion3D(eqx.Module):
         self,
         h: Float[Array, "Nz Ny Nx"],
         kappa: float | Float[Array, "Nz Ny Nx"],
+        wall: str = "closed",
     ) -> tuple[Float[Array, "Nz Ny Nx"], Float[Array, "Nz Ny Nx"]]:
         """Diagnostic diffusive face fluxes at U- and V-points, all z-levels.
 
@@ -424,6 +486,9 @@ class Diffusion3D(eqx.Module):
             Tracer field at T-points.
         kappa : float or Float[Array, "Nz Ny Nx"]
             Diffusion coefficient (scalar or T-point field).
+        wall : {"closed", "open"}, default "closed"
+            Lateral domain-wall face treatment (see :class:`Diffusion2D`).
+            ``"open"`` is not supported together with a ``mask``.
 
         Returns
         -------
@@ -433,6 +498,7 @@ class Diffusion3D(eqx.Module):
             ``flux_x`` is multiplied by ``mask.u`` and ``flux_y`` by
             ``mask.v`` at each z-level.
         """
+        _check_diffusion_wall(wall, self.mask)
         dx, dy = self.grid.dx, self.grid.dy
         kappa_arr = jnp.asarray(kappa)
         kappa_ax = 0 if kappa_arr.ndim >= 3 else None
@@ -440,7 +506,9 @@ class Diffusion3D(eqx.Module):
         if self.mask is None:
 
             def _apply_unmasked(h_k, kap_k):
-                return _diffusion_2d_fluxes_impl(h_k, kap_k, dx, dy, mu=None, mv=None)
+                return _diffusion_2d_fluxes_impl(
+                    h_k, kap_k, dx, dy, mu=None, mv=None, wall=wall
+                )
 
             fx, fy = eqx.filter_vmap(_apply_unmasked, in_axes=(0, kappa_ax))(
                 h, kappa_arr

--- a/finitevolx/_src/diffusion/diffusion.py
+++ b/finitevolx/_src/diffusion/diffusion.py
@@ -203,9 +203,25 @@ def _diffusion_2d_fluxes_impl(
 
     if wall == "open":
         # East-face flux at ALL faces i = 0 ... Nx-2, including the west
-        # (i=0) and east (i=Nx-2) domain-wall faces, reading the ghost ring.
-        kappa_x = kappa_arr[1:-1, :-1] if kappa_arr.ndim >= 2 else kappa_arr
-        kappa_y = kappa_arr[:-1, 1:-1] if kappa_arr.ndim >= 2 else kappa_arr
+        # (i=0) and east (i=Nx-2) domain-wall faces, reading the tracer ghost
+        # ring.  The face diffusivity uses the *source* (western/southern)
+        # T-cell value, but at the west/south walls that source cell is a
+        # coefficient ghost — and the public ``kappa`` contract does not
+        # require filling its ghost ring.  So clamp the west/south wall faces
+        # to the first *interior* coefficient cell instead of the ghost; this
+        # keeps the two low-side walls consistent with the east/north walls
+        # (which already source from interior cells) regardless of how the
+        # kappa halo was initialised.
+        if kappa_arr.ndim >= 2:
+            kappa_x = jnp.concatenate(
+                [kappa_arr[1:-1, 1:2], kappa_arr[1:-1, 1:-1]], axis=1
+            )
+            kappa_y = jnp.concatenate(
+                [kappa_arr[1:2, 1:-1], kappa_arr[1:-1, 1:-1]], axis=0
+            )
+        else:
+            kappa_x = kappa_arr
+            kappa_y = kappa_arr
         flux_x = flux_x.at[1:-1, :-1].set(kappa_x * (h[1:-1, 1:] - h[1:-1, :-1]) / dx)
         flux_y = flux_y.at[:-1, 1:-1].set(kappa_y * (h[1:, 1:-1] - h[:-1, 1:-1]) / dy)
     else:

--- a/finitevolx/_src/diffusion/diffusion.py
+++ b/finitevolx/_src/diffusion/diffusion.py
@@ -43,8 +43,11 @@ The class operators :class:`Diffusion2D` / :class:`Diffusion3D` also accept
 Dirichlet / periodic boundary applied to the ghost cells (e.g. via
 :class:`~finitevolx.BoundaryConditionSet`) then produces a diffusive flux
 through the wall.  The flux field stays single-valued, so the tendency is
-exactly flux-conservative.  ``wall="open"`` is not supported together with a
-mask.
+exactly flux-conservative for a **scalar** ``kappa``.  For a
+**spatially-varying** ``kappa`` the wall face reads the source-cell
+coefficient from the halo, so its halo must be filled consistently with the
+tracer BC (a periodic seam needs the wrapped coefficient) for conservation to
+hold.  ``wall="open"`` is not supported together with a mask.
 
 Custom closed-wall boundary conditions can also be imposed via the tracer
 field ``h``, the diffusivity ``kappa``, or by providing a ``Mask2D`` /
@@ -205,23 +208,16 @@ def _diffusion_2d_fluxes_impl(
         # East-face flux at ALL faces i = 0 ... Nx-2, including the west
         # (i=0) and east (i=Nx-2) domain-wall faces, reading the tracer ghost
         # ring.  The face diffusivity uses the *source* (western/southern)
-        # T-cell value, but at the west/south walls that source cell is a
-        # coefficient ghost — and the public ``kappa`` contract does not
-        # require filling its ghost ring.  So clamp the west/south wall faces
-        # to the first *interior* coefficient cell instead of the ghost; this
-        # keeps the two low-side walls consistent with the east/north walls
-        # (which already source from interior cells) regardless of how the
-        # kappa halo was initialised.
-        if kappa_arr.ndim >= 2:
-            kappa_x = jnp.concatenate(
-                [kappa_arr[1:-1, 1:2], kappa_arr[1:-1, 1:-1]], axis=1
-            )
-            kappa_y = jnp.concatenate(
-                [kappa_arr[1:2, 1:-1], kappa_arr[1:-1, 1:-1]], axis=0
-            )
-        else:
-            kappa_x = kappa_arr
-            kappa_y = kappa_arr
+        # T-cell value — the same convention as the interior faces — so the
+        # west/south wall faces read the coefficient ghost.  For a
+        # spatially-varying ``kappa`` its halo must therefore be filled
+        # consistently with the tracer BC (periodic kappa halo for a periodic
+        # tracer, etc.); this is unavoidable, because a periodic diffusive
+        # seam needs the *wrapped* coefficient and the paired wall faces would
+        # otherwise use one-sided interior values and stop cancelling.  A
+        # scalar ``kappa`` (the common case) conserves unconditionally.
+        kappa_x = kappa_arr[1:-1, :-1] if kappa_arr.ndim >= 2 else kappa_arr
+        kappa_y = kappa_arr[:-1, 1:-1] if kappa_arr.ndim >= 2 else kappa_arr
         flux_x = flux_x.at[1:-1, :-1].set(kappa_x * (h[1:-1, 1:] - h[1:-1, :-1]) / dx)
         flux_y = flux_y.at[:-1, 1:-1].set(kappa_y * (h[1:, 1:-1] - h[:-1, 1:-1]) / dy)
     else:

--- a/tests/test_open_walls.py
+++ b/tests/test_open_walls.py
@@ -213,6 +213,30 @@ def test_diffusion_open_is_exactly_conservative_2d(grid2d):
     )
 
 
+def test_diffusion_open_field_kappa_ignores_coefficient_ghost(grid2d):
+    """Field kappa with an *unfilled* (zero) ghost ring must not zero the
+    west/south wall fluxes — those faces source kappa from the interior cell."""
+    op = Diffusion2D(grid=grid2d)
+    rng = np.random.default_rng(11)
+    Ny, Nx = grid2d.Ny, grid2d.Nx
+    # Coefficient populated on interior T-cells only; ghost ring left at 0.
+    kappa = np.zeros((Ny, Nx))
+    kappa[1:-1, 1:-1] = rng.uniform(0.3, 1.0, size=(Ny - 2, Nx - 2))
+    kappa = jnp.asarray(kappa)
+    h = jnp.asarray(rng.normal(size=(Ny, Nx)).astype(np.float64))
+    fx, fy = op.fluxes(h, kappa, wall="open")
+    # West wall face (col 0) and south wall face (row 0) carry a real flux.
+    assert float(jnp.max(jnp.abs(fx[1:-1, 0]))) > 0.0
+    assert float(jnp.max(jnp.abs(fy[0, 1:-1]))) > 0.0
+    # Still exactly flux-conservative.
+    tend = op(h, kappa, wall="open")
+    x_term = jnp.sum(fx[1:-1, -2] - fx[1:-1, 0]) / grid2d.dx
+    y_term = jnp.sum(fy[-2, 1:-1] - fy[0, 1:-1]) / grid2d.dy
+    np.testing.assert_allclose(
+        float(jnp.sum(tend[1:-1, 1:-1])), float(x_term + y_term), rtol=1e-6, atol=1e-8
+    )
+
+
 def test_diffusion_dirichlet_wall_flux(grid2d):
     """A Dirichlet ghost drives a nonzero wall diffusive flux (open only)."""
     op = Diffusion2D(grid=grid2d)

--- a/tests/test_open_walls.py
+++ b/tests/test_open_walls.py
@@ -213,28 +213,29 @@ def test_diffusion_open_is_exactly_conservative_2d(grid2d):
     )
 
 
-def test_diffusion_open_field_kappa_ignores_coefficient_ghost(grid2d):
-    """Field kappa with an *unfilled* (zero) ghost ring must not zero the
-    west/south wall fluxes — those faces source kappa from the interior cell."""
+def test_diffusion_open_field_kappa_periodic_conserves(grid2d):
+    """Spatially-varying kappa: with the coefficient halo filled consistently
+    with the (periodic) tracer BC, the paired periodic seam faces share a
+    coefficient and the total interior tendency sums to zero (conservation).
+
+    A periodic diffusive seam intrinsically needs the wrapped coefficient, so
+    the kappa halo — like the tracer halo — must carry the BC.
+    """
     op = Diffusion2D(grid=grid2d)
     rng = np.random.default_rng(11)
     Ny, Nx = grid2d.Ny, grid2d.Nx
-    # Coefficient populated on interior T-cells only; ghost ring left at 0.
     kappa = np.zeros((Ny, Nx))
     kappa[1:-1, 1:-1] = rng.uniform(0.3, 1.0, size=(Ny - 2, Nx - 2))
-    kappa = jnp.asarray(kappa)
-    h = jnp.asarray(rng.normal(size=(Ny, Nx)).astype(np.float64))
-    fx, fy = op.fluxes(h, kappa, wall="open")
-    # West wall face (col 0) and south wall face (row 0) carry a real flux.
+    # Fill BOTH halos periodically (BC-consistent).
+    kappa = _periodic_x(_periodic_y(jnp.asarray(kappa)))
+    c = _periodic_x(_periodic_y(jnp.asarray(rng.normal(size=(Ny, Nx)))))
+    tend = op(c, kappa, wall="open")
+    # Divergence theorem on a periodic domain: the total tendency vanishes.
+    np.testing.assert_allclose(float(jnp.sum(tend[1:-1, 1:-1])), 0.0, atol=1e-4)
+    # Sanity: the wall faces carry real flux (kappa halo is nonzero, wrapped).
+    fx, fy = op.fluxes(c, kappa, wall="open")
     assert float(jnp.max(jnp.abs(fx[1:-1, 0]))) > 0.0
     assert float(jnp.max(jnp.abs(fy[0, 1:-1]))) > 0.0
-    # Still exactly flux-conservative.
-    tend = op(h, kappa, wall="open")
-    x_term = jnp.sum(fx[1:-1, -2] - fx[1:-1, 0]) / grid2d.dx
-    y_term = jnp.sum(fy[-2, 1:-1] - fy[0, 1:-1]) / grid2d.dy
-    np.testing.assert_allclose(
-        float(jnp.sum(tend[1:-1, 1:-1])), float(x_term + y_term), rtol=1e-6, atol=1e-8
-    )
 
 
 def test_diffusion_dirichlet_wall_flux(grid2d):

--- a/tests/test_open_walls.py
+++ b/tests/test_open_walls.py
@@ -1,0 +1,263 @@
+"""Tests for the ``wall="open"`` lateral-boundary mode (issue #234).
+
+The advection / diffusion operators default to ``wall="closed"`` — no-flux
+lateral walls, the correct convention for a closed / land-masked basin.
+``wall="open"`` instead assembles the domain-wall face fluxes from the
+caller-filled ghost ring, so Dirichlet / outflow / periodic lateral
+boundaries drive horizontal transport.  These tests check that:
+
+* the closed default is untouched (bit-for-bit),
+* open mode writes the previously-frozen wall-adjacent ring,
+* the open-mode flux field is single-valued so the tendency is exactly
+  flux-conservative (total interior tendency == wall-flux imbalance), and
+* periodic ghosts wrap and conserve mass.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from finitevolx._src.advection.advection import (
+    Advection1D,
+    Advection2D,
+    Advection3D,
+)
+from finitevolx._src.diffusion.diffusion import Diffusion2D, Diffusion3D
+from finitevolx._src.grid.cartesian import (
+    CartesianGrid1D,
+    CartesianGrid2D,
+    CartesianGrid3D,
+)
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+@pytest.fixture
+def grid1d():
+    return CartesianGrid1D.from_interior(8, 1.0)
+
+
+@pytest.fixture
+def grid2d():
+    return CartesianGrid2D.from_interior(nx_interior=8, ny_interior=8, Lx=8.0, Ly=8.0)
+
+
+@pytest.fixture
+def grid3d():
+    return CartesianGrid3D.from_interior(
+        nx_interior=8, ny_interior=8, nz_interior=4, Lx=8.0, Ly=8.0, Lz=4.0
+    )
+
+
+def _periodic_x(f):
+    return f.at[..., :, 0].set(f[..., :, -2]).at[..., :, -1].set(f[..., :, 1])
+
+
+def _periodic_y(f):
+    return f.at[..., 0, :].set(f[..., -2, :]).at[..., -1, :].set(f[..., 1, :])
+
+
+# ── closed default is unchanged ─────────────────────────────────────────────
+def test_advection_default_is_closed(grid3d):
+    op = Advection3D(grid=grid3d)
+    rng = np.random.default_rng(0)
+    shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+    c = jnp.asarray(rng.normal(size=shape).astype(np.float32))
+    u = jnp.asarray(rng.normal(size=shape).astype(np.float32))
+    v = jnp.asarray(rng.normal(size=shape).astype(np.float32))
+    default = op(c, u, v, method="weno5")
+    closed = op(c, u, v, method="weno5", wall="closed")
+    np.testing.assert_array_equal(np.asarray(default), np.asarray(closed))
+
+
+def test_diffusion_default_is_closed(grid3d):
+    op = Diffusion3D(grid=grid3d)
+    rng = np.random.default_rng(1)
+    shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+    c = jnp.asarray(rng.normal(size=shape).astype(np.float32))
+    np.testing.assert_array_equal(
+        np.asarray(op(c, 0.3)), np.asarray(op(c, 0.3, wall="closed"))
+    )
+
+
+def test_closed_freezes_wall_ring_open_updates_it(grid3d):
+    """Closed leaves the wall-adjacent interior ring at zero; open fills it."""
+    op = Advection3D(grid=grid3d)
+    c = jnp.zeros((grid3d.Nz, grid3d.Ny, grid3d.Nx)).at[2, 4, 4].set(1.0)
+    u = jnp.ones_like(c) * 0.7
+    v = jnp.ones_like(c) * 0.5
+    closed = op(c, u, v, method="weno5", wall="closed")
+    opened = op(c, u, v, method="weno5", wall="open")
+    # Wall-adjacent interior ring rows/cols (j=1 and i=1) are exactly 0 closed.
+    assert float(jnp.max(jnp.abs(closed[1:-1, 1, 1:-1]))) == 0.0
+    assert float(jnp.max(jnp.abs(closed[1:-1, 1:-1, 1]))) == 0.0
+    # Deep interior is identical between modes (open only changes wall fluxes).
+    np.testing.assert_allclose(
+        np.asarray(closed[1:-1, 2:-2, 2:-2]),
+        np.asarray(opened[1:-1, 2:-2, 2:-2]),
+        rtol=1e-5,
+        atol=1e-6,
+    )
+
+
+# ── exact flux-conservation (single-valued flux field) ──────────────────────
+def _wall_imbalance_2d(h, u, v, dx, dy):
+    """Independently reconstruct the first-order wall-face flux imbalance."""
+    west = jnp.where(u[:, 0] >= 0.0, h[:, 0], h[:, 1]) * u[:, 0]
+    east = jnp.where(u[:, -2] >= 0.0, h[:, -2], h[:, -1]) * u[:, -2]
+    south = jnp.where(v[0, :] >= 0.0, h[0, :], h[1, :]) * v[0, :]
+    north = jnp.where(v[-2, :] >= 0.0, h[-2, :], h[-1, :]) * v[-2, :]
+    x_term = jnp.sum(east[1:-1] - west[1:-1]) / dx
+    y_term = jnp.sum(north[1:-1] - south[1:-1]) / dy
+    return -(x_term + y_term)
+
+
+def test_advection_open_is_exactly_conservative_2d(grid2d):
+    """Σ(interior tendency) equals the wall-flux imbalance for every scheme."""
+    op = Advection2D(grid=grid2d)
+    rng = np.random.default_rng(3)
+    shape = (grid2d.Ny, grid2d.Nx)
+    for method in ("upwind1", "weno3", "weno5", "van_leer"):
+        c = jnp.asarray(rng.normal(size=shape).astype(np.float64))
+        u = jnp.asarray(rng.normal(size=shape).astype(np.float64))
+        v = jnp.asarray(rng.normal(size=shape).astype(np.float64))
+        tend = op(c, u, v, method=method, wall="open")
+        total = float(jnp.sum(tend[1:-1, 1:-1]))
+        expected = float(_wall_imbalance_2d(c, u, v, grid2d.dx, grid2d.dy))
+        np.testing.assert_allclose(total, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_advection_periodic_conserves_mass_2d(grid2d):
+    """Fully-periodic uniform advection conserves interior mass over time."""
+    op = Advection2D(grid=grid2d)
+    rng = np.random.default_rng(4)
+    c = jnp.asarray(rng.uniform(size=(grid2d.Ny, grid2d.Nx)).astype(np.float64))
+    u = jnp.ones_like(c) * 0.9
+    v = jnp.ones_like(c) * -0.6
+    dt = 0.05
+    mass0 = float(jnp.sum(c[1:-1, 1:-1]))
+    for _ in range(150):
+        c = _periodic_x(_periodic_y(c))
+        c = c + dt * op(c, u, v, method="upwind1", wall="open")
+    mass1 = float(jnp.sum(c[1:-1, 1:-1]))
+    # Exact in real arithmetic; tolerance covers float32 accumulation only.
+    np.testing.assert_allclose(mass1, mass0, rtol=1e-5)
+
+
+def test_advection_periodic_y_wraps_3d(grid3d):
+    """A blob advecting in +y past the north wall re-enters at the south."""
+    op = Advection3D(grid=grid3d)
+    c = jnp.zeros((grid3d.Nz, grid3d.Ny, grid3d.Nx)).at[2, -2, 4].set(1.0)
+    u = jnp.zeros_like(c)
+    v = jnp.ones_like(c) * 1.0
+    dt = 0.2
+    mass0 = float(jnp.sum(c[1:-1, 1:-1, 1:-1]))
+    for _ in range(60):
+        c = _periodic_y(c)
+        c = c + dt * op(c, u, v, method="upwind1", wall="open")
+    # Mass conserved (wrapped, not lost) and some mass has reached the south half.
+    np.testing.assert_allclose(float(jnp.sum(c[1:-1, 1:-1, 1:-1])), mass0, rtol=1e-6)
+    south_half = float(jnp.sum(c[2, 1 : grid3d.Ny // 2, 4]))
+    assert south_half > 1e-3
+
+
+def test_advection_outflow_loses_mass_only_through_open_boundary(grid2d):
+    """Outflow east + zero-Dirichlet elsewhere: mass leaves only downwind."""
+    op = Advection2D(grid=grid2d)
+    # Blob near the east side, uniform +x wind.
+    c = jnp.zeros((grid2d.Ny, grid2d.Nx)).at[4, -3].set(1.0)
+    u = jnp.ones_like(c) * 1.0
+    v = jnp.zeros_like(c)
+    dt = 0.1
+    masses = []
+    for _ in range(40):
+        # zero-gradient (outflow) east ghost; zero-Dirichlet elsewhere.
+        c = c.at[:, -1].set(c[:, -2])  # east outflow
+        c = c.at[:, 0].set(-c[:, 1])  # west dirichlet 0
+        c = c.at[0, :].set(-c[1, :]).at[-1, :].set(-c[-2, :])  # y walls dirichlet 0
+        c = c + dt * op(c, u, v, method="upwind1", wall="open")
+        masses.append(float(jnp.sum(c[1:-1, 1:-1])))
+    # Monotonically non-increasing, and strictly lost by the end (exited east).
+    assert all(b <= a + 1e-9 for a, b in itertools.pairwise(masses))
+    assert masses[-1] < 0.5
+
+
+def test_advection_1d_open_conservative(grid1d):
+    op = Advection1D(grid=grid1d)
+    rng = np.random.default_rng(5)
+    c = jnp.asarray(rng.normal(size=(grid1d.Nx,)).astype(np.float64))
+    u = jnp.asarray(rng.normal(size=(grid1d.Nx,)).astype(np.float64))
+    tend = op(c, u, method="weno5", wall="open")
+    total = float(jnp.sum(tend[1:-1]))
+    west = float(jnp.where(u[0] >= 0.0, c[0], c[1]) * u[0])
+    east = float(jnp.where(u[-2] >= 0.0, c[-2], c[-1]) * u[-2])
+    np.testing.assert_allclose(total, -(east - west) / grid1d.dx, rtol=1e-6, atol=1e-6)
+
+
+# ── diffusion open mode ─────────────────────────────────────────────────────
+def test_diffusion_open_is_exactly_conservative_2d(grid2d):
+    op = Diffusion2D(grid=grid2d)
+    rng = np.random.default_rng(6)
+    h = jnp.asarray(rng.normal(size=(grid2d.Ny, grid2d.Nx)).astype(np.float64))
+    dx, dy = grid2d.dx, grid2d.dy
+    tend = op(h, 0.7, wall="open")
+    fx, fy = op.fluxes(h, 0.7, wall="open")
+    # Σ tendency telescopes to the wall-face flux imbalance.
+    x_term = jnp.sum(fx[1:-1, -2] - fx[1:-1, 0]) / dx
+    y_term = jnp.sum(fy[-2, 1:-1] - fy[0, 1:-1]) / dy
+    np.testing.assert_allclose(
+        float(jnp.sum(tend[1:-1, 1:-1])), float(x_term + y_term), rtol=1e-6, atol=1e-8
+    )
+
+
+def test_diffusion_dirichlet_wall_flux(grid2d):
+    """A Dirichlet ghost drives a nonzero wall diffusive flux (open only)."""
+    op = Diffusion2D(grid=grid2d)
+    kappa = 0.5
+    h = jnp.ones((grid2d.Ny, grid2d.Nx))  # uniform interior => zero interior flux
+    # West Dirichlet with boundary value 0 => ghost = 2*0 - interior = -1.
+    h = h.at[:, 0].set(-h[:, 1])
+    closed = op(h, kappa, wall="closed")
+    opened = op(h, kappa, wall="open")
+    # Closed: no wall flux anywhere -> zero tendency for the uniform interior.
+    np.testing.assert_allclose(np.asarray(closed[1:-1, 1:-1]), 0.0, atol=1e-6)
+    # Open: the west edge column (i=1) gets a nonzero inward diffusive flux.
+    west_edge = opened[1:-1, 1]
+    assert float(jnp.max(jnp.abs(west_edge))) > 1e-3
+    # Cells away from any wall stay zero (uniform field, interior flux == 0).
+    np.testing.assert_allclose(np.asarray(opened[2:-2, 2:-2]), 0.0, atol=1e-6)
+
+
+def test_diffusion_periodic_conserves_mass_3d(grid3d):
+    op = Diffusion3D(grid=grid3d)
+    rng = np.random.default_rng(7)
+    shape = (grid3d.Nz, grid3d.Ny, grid3d.Nx)
+    c = jnp.asarray(rng.normal(size=shape).astype(np.float64))
+    dt = 0.02
+    mass0 = float(jnp.sum(c[1:-1, 1:-1, 1:-1]))
+    for _ in range(80):
+        c = _periodic_x(_periodic_y(c))
+        c = c + dt * op(c, 0.4, wall="open")
+    # Exact in real arithmetic; tolerance covers float32 accumulation only.
+    np.testing.assert_allclose(float(jnp.sum(c[1:-1, 1:-1, 1:-1])), mass0, rtol=1e-5)
+
+
+# ── validation ──────────────────────────────────────────────────────────────
+def test_invalid_wall_raises(grid2d):
+    op = Advection2D(grid=grid2d)
+    c = jnp.zeros((grid2d.Ny, grid2d.Nx))
+    with pytest.raises(ValueError, match=r"wall must be"):
+        op(c, c, c, method="upwind1", wall="bogus")
+
+
+def test_open_with_mask_raises(grid2d):
+    from finitevolx._src.mask import Mask2D
+
+    mask = Mask2D.from_mask(jnp.ones((grid2d.Ny, grid2d.Nx)))
+    op = Advection2D(grid=grid2d, mask=mask)
+    c = jnp.zeros((grid2d.Ny, grid2d.Nx))
+    with pytest.raises(NotImplementedError, match=r"open.*mask|mask"):
+        op(c, c, c, method="weno5", wall="open")


### PR DESCRIPTION
## Summary

Closes #234.

`Advection{1,2,3}D` and `Diffusion{2,3}D` are written for closed / land-masked
basins: advection freezes the wall-adjacent interior ring and diffusion
hard-codes zero wall-face fluxes. finitevolX already ships a first-class BC
subsystem (`BoundaryConditionSet.open()/.closed()/.periodic()`, the 1D BC
atoms, `enforce_periodic`) that fills the ghost ring — but the tendency
operators never read it at the walls, so there was **no supported path for
open (outflow / inflow-Dirichlet) or periodic lateral boundaries**. (The
existing periodic tests even validate only the deep interior `[2:-2, 2:-2]`
"to avoid ghost-cell contamination" — working around exactly this gap.)

This adds an opt-in `wall` argument to the operators. The BC layer stays the
sole owner of ghost-filling; the operators just gain the ability to consume it
at the walls.

## What changed

`wall={"closed", "open"}`, default `"closed"` — **bit-for-bit unchanged** for
every existing caller:

- **`"closed"`** (default): current behavior — no-flux lateral walls, ghost
  ring ignored by the horizontal term.
- **`"open"`**: the operators compute the domain-wall face fluxes from the
  caller-filled ghost ring and write the full interior `[1:-1, …]`.
  - *Advection*: the two wall faces per axis use a first-order upwind
    reconstruction that reads the ghost; interior faces keep the requested
    high-order `method`. The flux field stays single-valued → the tendency is
    **exactly mass-conservative** and periodic ghosts wrap.
  - *Diffusion*: the wall faces get `κ·(h_edge − h_ghost)/dx` from the ghost,
    extending the existing interior flux field → **exactly flux-conservative**.

Dirichlet / outflow / periodic lateral BCs applied to the ghost cells
beforehand (e.g. via `BoundaryConditionSet`) now drive horizontal transport.
`"open"` is rejected together with a `mask` (the ghost-flux path assumes a
rectangular domain with no interior land).

## Tests

New `tests/test_open_walls.py`:
- closed-default regression (open vs default identical; deep interior
  unchanged between modes),
- **exact flux-conservation** per scheme (Σ interior tendency == wall-flux
  imbalance) for advection (1D/2D) and diffusion,
- periodic wrap + mass conservation over time (advection & diffusion),
- outflow mass budget (mass leaves only through the open boundary),
- Dirichlet wall diffusive flux,
- validation (`wall="bogus"` raises; `open` + `mask` raises).

Full suite green: **2074 passed**. `ruff check` / `ruff format --check` / `ty`
all pass.

## Downstream

Unblocks jejjohnson/plumax#25 (advection) and #26 (diffusion): `les_fvm`
already fills the ghost ring every RHS step, so wiring is a one-line
`wall="open"` per operator (follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3NxHCEGifJAEEu8kjKNKb)_